### PR TITLE
feat(telegram): add /summary, /help, and /accounts commands

### DIFF
--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -82,6 +82,101 @@ const pendingExpenses = new Map<number, {
   expiresAt: number;
 }>();
 
+// Handle summary command - /summary [today|week|month]
+async function handleSummaryCommand(chatId: number, args: string) {
+  const userSettings = await db.userSettings.findFirst({
+    where: { telegramChatId: chatId.toString() },
+  });
+
+  if (!userSettings) {
+    await sendTelegramMessage(
+      chatId,
+      "❌ Your Telegram account is not linked. Please link it from the Chamber dashboard first."
+    );
+    return;
+  }
+
+  const period = args || "today";
+  const now = new Date();
+  let startDate: Date;
+  const endDate: Date = new Date();
+  let periodLabel: string;
+
+  if (period === "today") {
+    startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    periodLabel = "Today";
+  } else if (period === "week") {
+    startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    periodLabel = "Last 7 Days";
+  } else if (period === "month") {
+    startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    periodLabel = "This Month";
+  } else {
+    await sendTelegramMessage(
+      chatId,
+      "❓ Usage: <code>/summary [today|week|month]</code>\n\nExamples:\n• <code>/summary</code> - Today's summary\n• <code>/summary week</code> - Last 7 days\n• <code>/summary month</code> - This month"
+    );
+    return;
+  }
+
+  const expenses = await db.expense.findMany({
+    where: {
+      userId: userSettings.userId,
+      date: {
+        gte: startDate,
+        lte: endDate,
+      },
+    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    select: {
+      amount: true,
+      category: true,
+      description: true,
+      merchant: true,
+      date: true,
+    },
+  });
+
+  let totalSpent = 0;
+  const categoryBreakdown: Record<string, number> = {};
+  const recentExpenses = expenses.slice(0, 5);
+
+  for (const exp of expenses) {
+    totalSpent += exp.amount;
+    categoryBreakdown[exp.category] = (categoryBreakdown[exp.category] || 0) + exp.amount;
+  }
+
+  const currency = userSettings.currency || "INR";
+  const currencySymbol = currency === "INR" ? "₹" : "$";
+
+  let message = `📊 <b>${periodLabel} Summary</b>\n\n`;
+  message += `💰 <b>Total:</b> ${currencySymbol}${totalSpent.toFixed(2)}\n`;
+  message += `📝 <b>Transactions:</b> ${expenses.length}\n`;
+
+  if (expenses.length > 0) {
+    const sortedCategories = Object.entries(categoryBreakdown)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+
+    message += `\n<b>By Category:</b>\n`;
+    for (const [category, amount] of sortedCategories) {
+      const percentage = ((amount / totalSpent) * 100).toFixed(0);
+      message += `• ${category}: ${currencySymbol}${amount.toFixed(2)} (${percentage}%)\n`;
+    }
+
+    message += `\n<b>Recent Transactions:</b>\n`;
+    for (const exp of recentExpenses) {
+      const label = exp.merchant || exp.description || exp.category;
+      const date = new Date(exp.date).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+      message += `• ${label}: ${currencySymbol}${exp.amount.toFixed(2)} (${date})\n`;
+    }
+  } else {
+    message += `\n<i>No expenses recorded for ${periodLabel.toLowerCase()}.</i>`;
+  }
+
+  await sendTelegramMessage(chatId, message);
+}
+
 // Icon mapping for account types in Telegram keyboard
 const ACCOUNT_TYPE_ICONS: Record<string, string> = {
   BANK: "\u{1F3E6}",
@@ -733,6 +828,9 @@ export async function POST(request: NextRequest) {
         chatId,
         "👋 Welcome to Chamber!\n\nTo link your account, please generate a linking code from the Chamber dashboard and send:\n<code>/start YOUR_CODE</code>"
       );
+    } else if (text.startsWith("/summary")) {
+      const args = text.replace("/summary", "").trim().toLowerCase();
+      await handleSummaryCommand(chatId, args);
     } else if (text && !text.startsWith("/")) {
       // If there's a pending expense, treat this as a correction
       if (pendingExpenses.has(chatId)) {

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -177,7 +177,90 @@ async function handleSummaryCommand(chatId: number, args: string) {
   await sendTelegramMessage(chatId, message);
 }
 
-// Icon mapping for account types in Telegram keyboard
+// Handle help command - /help
+async function handleHelpCommand(chatId: number) {
+  const helpMessage = `🤖 <b>Chamber Bot Commands</b>
+
+<b>Account Setup</b>
+• <code>/start &lt;code&gt;</code> - Link your Chamber account
+
+<b>Expense Management</b>
+• <code>/summary [today|week|month]</code> - View spending summary
+• <code>/accounts</code> - Check account balances
+• Send any text message - Add an expense via AI
+• Send a photo - Extract expense from receipt
+• Send a PDF - Extract expense from invoice
+
+<b>Need Help?</b>
+• Visit: <a href="https://chamber.vercel.app">chamber.vercel.app</a>
+
+💡 <i>Tip: You can also send voice messages to add expenses!</i>`;
+
+  await sendTelegramMessage(chatId, helpMessage);
+}
+
+// Handle accounts command - /accounts
+async function handleAccountsCommand(chatId: number) {
+  const userSettings = await db.userSettings.findFirst({
+    where: { telegramChatId: chatId.toString() },
+  });
+
+  if (!userSettings) {
+    await sendTelegramMessage(
+      chatId,
+      "❌ Your Telegram account is not linked. Please link it from the Chamber dashboard first.\n\nUse: <code>/start YOUR_CODE</code>"
+    );
+    return;
+  }
+
+  const accounts = await db.account.findMany({
+    where: { userId: userSettings.userId, isActive: true },
+    orderBy: [{ type: "asc" }, { name: "asc" }],
+  });
+
+  if (accounts.length === 0) {
+    await sendTelegramMessage(
+      chatId,
+      "📭 You don't have any active accounts yet.\n\nAdd accounts from the Chamber dashboard."
+    );
+    return;
+  }
+
+  const currency = userSettings.currency || "INR";
+  const currencySymbol = currency === "INR" ? "₹" : "$";
+
+  let totalBalance = 0;
+  let message = `📊 <b>Your Accounts</b>\n\n`;
+
+  // Group accounts by type
+  const accountsByType: Record<string, typeof accounts> = {};
+  for (const account of accounts) {
+    if (!accountsByType[account.type]) {
+      accountsByType[account.type] = [];
+    }
+    accountsByType[account.type].push(account);
+  }
+
+  // Display accounts grouped by type
+  const typeOrder = ["BANK", "INVESTMENT", "WALLET", "CASH", "CREDIT_CARD", "DEBIT_CARD", "OTHER"];
+  
+  for (const type of typeOrder) {
+    const typeAccounts = accountsByType[type];
+    if (!typeAccounts || typeAccounts.length === 0) continue;
+
+    const icon = ACCOUNT_TYPE_ICONS[type] || "💰";
+    
+    for (const account of typeAccounts) {
+      const balance = Number(account.currentBalance);
+      totalBalance += balance;
+      message += `${icon} <b>${account.name}</b>: ${currencySymbol}${balance.toFixed(2)}\n`;
+    }
+  }
+
+  message += `\n💵 <b>Total Balance:</b> ${currencySymbol}${totalBalance.toFixed(2)}`;
+
+  await sendTelegramMessage(chatId, message);
+}
 const ACCOUNT_TYPE_ICONS: Record<string, string> = {
   BANK: "\u{1F3E6}",
   INVESTMENT: "\u{1F4C8}",
@@ -831,6 +914,10 @@ export async function POST(request: NextRequest) {
     } else if (text.startsWith("/summary")) {
       const args = text.replace("/summary", "").trim().toLowerCase();
       await handleSummaryCommand(chatId, args);
+    } else if (text.startsWith("/accounts")) {
+      await handleAccountsCommand(chatId);
+    } else if (text.startsWith("/help")) {
+      await handleHelpCommand(chatId);
     } else if (text && !text.startsWith("/")) {
       // If there's a pending expense, treat this as a correction
       if (pendingExpenses.has(chatId)) {

--- a/tests/unit/api/telegram/webhook.test.ts
+++ b/tests/unit/api/telegram/webhook.test.ts
@@ -11,6 +11,9 @@ const mockDb = {
     expense: {
         findMany: vi.fn(),
     },
+    account: {
+        findMany: vi.fn(),
+    },
     linkingCode: {
         findFirst: vi.fn(),
         update: vi.fn(),
@@ -373,6 +376,238 @@ describe("Telegram Webhook", () => {
             expect(sendMessageCall).toBeDefined();
             const body = JSON.parse(String(sendMessageCall?.[1]?.body));
             expect(body.text).toContain("$50.00");
+            expect(body.text).not.toContain("₹");
+        });
+    });
+
+    describe("Help Command", () => {
+        it("should show help message for /help command", async () => {
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/help",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("Chamber Bot Commands");
+            expect(body.text).toContain("/start");
+            expect(body.text).toContain("/summary");
+            expect(body.text).toContain("/accounts");
+        });
+    });
+
+    describe("Accounts Command", () => {
+        it("should show error when user is not linked", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue(null);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/accounts",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            expect(fetch).toHaveBeenCalledWith(
+                expect.stringContaining("/sendMessage"),
+                expect.objectContaining({
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: expect.stringContaining("not linked"),
+                })
+            );
+        });
+
+        it("should show message when user has no accounts", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            mockDb.account.findMany.mockResolvedValue([]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/accounts",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("don't have any active accounts");
+        });
+
+        it("should show account balances for /accounts command", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            mockDb.account.findMany.mockResolvedValue([
+                {
+                    id: "acc-1",
+                    name: "HDFC Bank",
+                    type: "BANK",
+                    currentBalance: 45230,
+                    isActive: true,
+                },
+                {
+                    id: "acc-2",
+                    name: "Cash Wallet",
+                    type: "WALLET",
+                    currentBalance: 2150,
+                    isActive: true,
+                },
+                {
+                    id: "acc-3",
+                    name: "Investments",
+                    type: "INVESTMENT",
+                    currentBalance: 125000,
+                    isActive: true,
+                },
+            ]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/accounts",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("Your Accounts");
+            expect(body.text).toContain("HDFC Bank");
+            expect(body.text).toContain("₹45230.00");
+            expect(body.text).toContain("Cash Wallet");
+            expect(body.text).toContain("₹2150.00");
+            expect(body.text).toContain("Investments");
+            expect(body.text).toContain("₹125000.00");
+            expect(body.text).toContain("Total Balance");
+            expect(body.text).toContain("₹172380.00");
+        });
+
+        it("should use USD currency for accounts when set", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "USD",
+                telegramChatId: "123456",
+            });
+
+            mockDb.account.findMany.mockResolvedValue([
+                {
+                    id: "acc-1",
+                    name: "Chase Bank",
+                    type: "BANK",
+                    currentBalance: 5000,
+                    isActive: true,
+                },
+            ]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/accounts",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("$5000.00");
             expect(body.text).not.toContain("₹");
         });
     });

--- a/tests/unit/api/telegram/webhook.test.ts
+++ b/tests/unit/api/telegram/webhook.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock fetch for Telegram API calls
+global.fetch = vi.fn();
+
+// Mock database client
+const mockDb = {
+    userSettings: {
+        findFirst: vi.fn(),
+    },
+    expense: {
+        findMany: vi.fn(),
+    },
+    linkingCode: {
+        findFirst: vi.fn(),
+        update: vi.fn(),
+    },
+};
+
+vi.mock("@/lib/db", () => ({
+    db: mockDb,
+}));
+
+// Mock R2 upload
+vi.mock("@aws-sdk/client-s3", () => ({
+    S3Client: vi.fn(() => ({
+        send: vi.fn().mockResolvedValue({}),
+    })),
+    PutObjectCommand: vi.fn(),
+}));
+
+// Mock AI module
+vi.mock("@/lib/ai", () => ({
+    parseExpenseWithAI: vi.fn(),
+    parseReceiptWithVision: vi.fn(),
+    parsePDFWithVision: vi.fn(),
+}));
+
+// Mock accounts actions
+vi.mock("@/lib/actions/accounts", () => ({
+    getAccountsByUserId: vi.fn(),
+}));
+
+// Mock subscription alerts
+vi.mock("@/lib/subscription-alerts", () => ({
+    checkAndSendSubscriptionAlerts: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("Telegram Webhook", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fetch).mockClear();
+        process.env.TELEGRAM_BOT_TOKEN = "test-bot-token";
+        process.env.TELEGRAM_WEBHOOK_SECRET = "test-webhook-secret";
+    });
+
+    describe("Summary Command", () => {
+        it("should show error when user is not linked", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue(null);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            expect(fetch).toHaveBeenCalledWith(
+                expect.stringContaining("/sendMessage"),
+                expect.objectContaining({
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: expect.stringContaining("not linked"),
+                })
+            );
+        });
+
+        it("should show today's summary for /summary command", async () => {
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            mockDb.expense.findMany.mockResolvedValue([
+                {
+                    amount: 250,
+                    category: "Food",
+                    description: "Lunch",
+                    merchant: "Restaurant",
+                    date: new Date(),
+                },
+                {
+                    amount: 100,
+                    category: "Travel",
+                    description: "Uber",
+                    merchant: null,
+                    date: new Date(),
+                },
+            ]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("Today Summary");
+            expect(body.text).toContain("₹350.00");
+            expect(body.text).toContain("Food");
+            expect(body.text).toContain("Travel");
+            expect(body.text).toContain("Restaurant");
+            expect(body.text).toContain("Uber");
+        });
+
+        it("should show weekly summary for /summary week command", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            mockDb.expense.findMany.mockResolvedValue([
+                {
+                    amount: 500,
+                    category: "Shopping",
+                    description: "Groceries",
+                    merchant: "BigBasket",
+                    date: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+                },
+            ]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary week",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("Last 7 Days");
+        });
+
+        it("should show monthly summary for /summary month command", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            mockDb.expense.findMany.mockResolvedValue([
+                {
+                    amount: 1000,
+                    category: "Bills",
+                    description: "Electricity",
+                    merchant: null,
+                    date: new Date(),
+                },
+            ]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary month",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("This Month");
+        });
+
+        it("should show usage help for invalid summary command", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary invalid",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("Usage:");
+            expect(body.text).toContain("/summary [today|week|month]");
+        });
+
+        it("should show 'no expenses' message when no data exists", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
+            });
+
+            mockDb.expense.findMany.mockResolvedValue([]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("No expenses recorded");
+        });
+
+        it("should use USD currency when user has USD set", async () => {
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "USD",
+                telegramChatId: "123456",
+            });
+
+            mockDb.expense.findMany.mockResolvedValue([
+                {
+                    amount: 50,
+                    category: "Food",
+                    description: "Coffee",
+                    merchant: "Starbucks",
+                    date: new Date(),
+                },
+            ]);
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+            const request = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 123,
+                    message: {
+                        message_id: 1,
+                        from: { id: 123456, first_name: "Test" },
+                        chat: { id: 123456, type: "private" },
+                        date: Date.now(),
+                        text: "/summary",
+                    },
+                }),
+            });
+
+            await POST(request);
+
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const sendMessageCall = fetchCalls.find((call) =>
+                String(call[0]).includes("/sendMessage")
+            );
+
+            expect(sendMessageCall).toBeDefined();
+            const body = JSON.parse(String(sendMessageCall?.[1]?.body));
+            expect(body.text).toContain("$50.00");
+            expect(body.text).not.toContain("₹");
+        });
+    });
+});


### PR DESCRIPTION
Add Telegram bot commands:

**Summary Commands:**
- /summary - Today's spending summary
- /summary week - Last 7 days summary
- /summary month - Current month summary

**Help Command:**
- /help - Shows all available commands
  - Account Setup: /start
  - Expense Management: /summary, /accounts
  - Quick add: Text messages, photos, PDFs

**Accounts Command:**
- /accounts - Display account balances
  - Groups accounts by type (Bank, Investment, Wallet, Cash, etc.)
  - Shows individual account balances
  - Calculates total net worth
  - Supports user's configured currency (INR/$)

**Features:**
- Total spent with user's currency (INR/$)
- Transaction count
- Category breakdown with percentages
- Recent transactions list
- Handles unlinked users and empty accounts gracefully

**Tests:**
- 11 unit tests covering all scenarios
  - Summary: 7 tests (today, week, month, invalid args, empty data, currency)
  - Help: 1 test
  - Accounts: 3 tests (unlinked, empty, with balances)