### PR TITLE
feat(accounts): add bank transfer functionality with atomic balance updates

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tabler/icons-react";
 import { AccountList } from "@/components/account-list";
 import { AddAccountDialog } from "@/components/add-account-dialog";
+import { BankTransferDialog } from "@/components/bank-transfer-dialog";
 
 export default async function AccountsPage() {
   const [accounts, stats, settings] = await Promise.all([
@@ -36,7 +37,18 @@ export default async function AccountsPage() {
             Track your bank balances and investments
           </p>
         </div>
-        <AddAccountDialog currency={settings.currency} />
+        <div className="flex items-center gap-2">
+          <BankTransferDialog
+            accounts={accounts.map((a) => ({
+              id: a.id,
+              name: a.name,
+              type: a.type,
+              currentBalance: a.currentBalance,
+            }))}
+            currency={settings.currency}
+          />
+          <AddAccountDialog currency={settings.currency} />
+        </div>
       </div>
 
       {/* Stats Cards */}

--- a/components/bank-transfer-dialog.tsx
+++ b/components/bank-transfer-dialog.tsx
@@ -57,10 +57,17 @@ export function BankTransferDialog({ accounts, currency }: BankTransferDialogPro
   const [note, setNote] = useState("");
   const [date, setDate] = useState(toLocalDateString());
 
-  const currencySymbol =
-    currency === "INR" ? "₹" :
-    currency === "USD" ? "$" :
-    currency === "EUR" ? "€" : "£";
+  const currencySymbol = (() => {
+    try {
+      return (
+        new Intl.NumberFormat("en", { style: "currency", currency, minimumFractionDigits: 0 })
+          .formatToParts(0)
+          .find((p) => p.type === "currency")?.value ?? currency
+      );
+    } catch {
+      return currency;
+    }
+  })();
 
   const formatCurrency = (val: number) =>
     new Intl.NumberFormat("en-IN", {

--- a/components/bank-transfer-dialog.tsx
+++ b/components/bank-transfer-dialog.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { IconArrowsTransferDown } from "@tabler/icons-react";
+import { createTransfer } from "@/lib/actions/transfers";
+
+type Account = {
+  id: string;
+  name: string;
+  type: string;
+  currentBalance: number;
+};
+
+type BankTransferDialogProps = {
+  accounts: Account[];
+  currency: string;
+};
+
+function toLocalDateString() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function BankTransferDialog({ accounts, currency }: BankTransferDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [fromAccountId, setFromAccountId] = useState("");
+  const [toAccountId, setToAccountId] = useState("");
+  const [amount, setAmount] = useState("");
+  const [note, setNote] = useState("");
+  const [date, setDate] = useState(toLocalDateString());
+
+  const currencySymbol =
+    currency === "INR" ? "₹" :
+    currency === "USD" ? "$" :
+    currency === "EUR" ? "€" : "£";
+
+  const formatCurrency = (val: number) =>
+    new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(val);
+
+  const resetForm = () => {
+    setFromAccountId("");
+    setToAccountId("");
+    setAmount("");
+    setNote("");
+    setDate(toLocalDateString());
+    setError(null);
+  };
+
+  const fromAccount = accounts.find((a) => a.id === fromAccountId);
+  const toAccount = accounts.find((a) => a.id === toAccountId);
+
+  const parsedAmount = parseFloat(amount);
+  const hasInsufficientFunds =
+    fromAccount && !isNaN(parsedAmount) && parsedAmount > fromAccount.currentBalance;
+
+  const isValid =
+    fromAccountId &&
+    toAccountId &&
+    fromAccountId !== toAccountId &&
+    amount &&
+    !isNaN(parsedAmount) &&
+    parsedAmount > 0 &&
+    !hasInsufficientFunds;
+
+  const handleSubmit = async () => {
+    if (!isValid) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [year, month, day] = date.split("-").map(Number);
+      const transferDate = new Date(year, month - 1, day);
+
+      await createTransfer({
+        fromAccountId,
+        toAccountId,
+        amount: parsedAmount,
+        note: note.trim() || undefined,
+        date: transferDate,
+      });
+
+      resetForm();
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Transfer failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Filter out the selected account from the other side
+  const toAccountOptions = accounts.filter((a) => a.id !== fromAccountId);
+  const fromAccountOptions = accounts.filter((a) => a.id !== toAccountId);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(val) => {
+        setOpen(val);
+        if (!val) resetForm();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <IconArrowsTransferDown className="mr-2 h-4 w-4" />
+          Transfer
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle>Bank Transfer</DialogTitle>
+          <DialogDescription>
+            Move money between your accounts. Both balances will be updated immediately.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {/* From Account */}
+          <div className="grid gap-2">
+            <Label htmlFor="fromAccount">From Account *</Label>
+            <Select
+              value={fromAccountId}
+              onValueChange={(v) => {
+                setFromAccountId(v);
+                if (v === toAccountId) setToAccountId("");
+              }}
+            >
+              <SelectTrigger id="fromAccount">
+                <SelectValue placeholder="Select source account" />
+              </SelectTrigger>
+              <SelectContent>
+                {fromAccountOptions.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    <span>{a.name}</span>
+                    <span className="ml-2 text-muted-foreground text-xs">
+                      {formatCurrency(a.currentBalance)}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {fromAccount && (
+              <p className="text-xs text-muted-foreground">
+                Available balance: {formatCurrency(fromAccount.currentBalance)}
+              </p>
+            )}
+          </div>
+
+          {/* To Account */}
+          <div className="grid gap-2">
+            <Label htmlFor="toAccount">To Account *</Label>
+            <Select
+              value={toAccountId}
+              onValueChange={(v) => {
+                setToAccountId(v);
+                if (v === fromAccountId) setFromAccountId("");
+              }}
+            >
+              <SelectTrigger id="toAccount">
+                <SelectValue placeholder="Select destination account" />
+              </SelectTrigger>
+              <SelectContent>
+                {toAccountOptions.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    <span>{a.name}</span>
+                    <span className="ml-2 text-muted-foreground text-xs">
+                      {formatCurrency(a.currentBalance)}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Amount */}
+          <div className="grid gap-2">
+            <Label htmlFor="amount">Amount *</Label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                {currencySymbol}
+              </span>
+              <Input
+                id="amount"
+                type="number"
+                placeholder="0.00"
+                min="0.01"
+                step="0.01"
+                className="pl-8"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+              />
+            </div>
+            {hasInsufficientFunds && (
+              <p className="text-xs text-destructive">
+                Insufficient funds. Available: {formatCurrency(fromAccount!.currentBalance)}
+              </p>
+            )}
+          </div>
+
+          {/* Preview */}
+          {fromAccount && toAccount && parsedAmount > 0 && !hasInsufficientFunds && (
+            <div className="rounded-md border bg-muted/40 px-4 py-3 text-sm grid gap-1">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{fromAccount.name} after</span>
+                <span className="font-medium">
+                  {formatCurrency(fromAccount.currentBalance - parsedAmount)}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{toAccount.name} after</span>
+                <span className="font-medium">
+                  {formatCurrency(toAccount.currentBalance + parsedAmount)}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Date */}
+          <div className="grid gap-2">
+            <Label htmlFor="transferDate">Date</Label>
+            <Input
+              id="transferDate"
+              type="date"
+              value={date}
+              max={toLocalDateString()}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </div>
+
+          {/* Note */}
+          <div className="grid gap-2">
+            <Label htmlFor="note">Note (optional)</Label>
+            <Textarea
+              id="note"
+              placeholder="e.g., Moving savings to investments"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={2}
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading || !isValid}>
+            {loading ? "Transferring..." : "Transfer"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/actions/accounts.ts
+++ b/lib/actions/accounts.ts
@@ -245,6 +245,17 @@ export async function deleteAccount(id: string) {
 
   if (!existing) throw new Error("Account not found");
 
+  // Prevent deletion if transfers exist — the linked account's balance would be left incorrect
+  const transferCount = await db.transfer.count({
+    where: { OR: [{ fromAccountId: id }, { toAccountId: id }] },
+  });
+
+  if (transferCount > 0) {
+    throw new Error(
+      `Cannot delete account with existing transfers. Please delete the ${transferCount} transfer${transferCount === 1 ? "" : "s"} first.`
+    );
+  }
+
   // Delete account (cascade will delete history)
   await db.account.delete({
     where: { id },

--- a/lib/actions/transfers.ts
+++ b/lib/actions/transfers.ts
@@ -37,21 +37,23 @@ export async function createTransfer(input: CreateTransferInput) {
     throw new Error("Transfer amount must be greater than zero");
   }
 
-  // Verify both accounts belong to this user
-  const [fromAccount, toAccount] = await Promise.all([
-    db.account.findFirst({ where: { id: input.fromAccountId, userId, isActive: true } }),
-    db.account.findFirst({ where: { id: input.toAccountId, userId, isActive: true } }),
-  ]);
-
-  if (!fromAccount) throw new Error("Source account not found");
-  if (!toAccount) throw new Error("Destination account not found");
-
   const transferDate = input.date ?? new Date();
-  const newFromBalance = fromAccount.currentBalance - input.amount;
-  const newToBalance = toAccount.currentBalance + input.amount;
 
-  // Execute all DB operations in a transaction
+  // Accounts are fetched inside the transaction to prevent TOCTOU race conditions.
+  // Atomic increments are used for balance updates to avoid stale-read overwrites.
   const transfer = await db.$transaction(async (tx) => {
+    const [fromAccount, toAccount] = await Promise.all([
+      tx.account.findFirst({ where: { id: input.fromAccountId, userId, isActive: true } }),
+      tx.account.findFirst({ where: { id: input.toAccountId, userId, isActive: true } }),
+    ]);
+
+    if (!fromAccount) throw new Error("Source account not found");
+    if (!toAccount) throw new Error("Destination account not found");
+
+    if (fromAccount.currentBalance < input.amount) {
+      throw new Error("Insufficient funds");
+    }
+
     const created = await tx.transfer.create({
       data: {
         userId,
@@ -63,29 +65,29 @@ export async function createTransfer(input: CreateTransferInput) {
       },
     });
 
-    await tx.account.update({
+    const updatedFrom = await tx.account.update({
       where: { id: input.fromAccountId },
-      data: { currentBalance: newFromBalance },
+      data: { currentBalance: { increment: -input.amount } },
     });
 
     await tx.balanceHistory.create({
       data: {
         accountId: input.fromAccountId,
-        balance: newFromBalance,
+        balance: updatedFrom.currentBalance,
         note: `Transfer to ${toAccount.name}${input.note ? ` — ${input.note}` : ""}`,
         date: transferDate,
       },
     });
 
-    await tx.account.update({
+    const updatedTo = await tx.account.update({
       where: { id: input.toAccountId },
-      data: { currentBalance: newToBalance },
+      data: { currentBalance: { increment: input.amount } },
     });
 
     await tx.balanceHistory.create({
       data: {
         accountId: input.toAccountId,
-        balance: newToBalance,
+        balance: updatedTo.currentBalance,
         note: `Transfer from ${fromAccount.name}${input.note ? ` — ${input.note}` : ""}`,
         date: transferDate,
       },
@@ -135,44 +137,45 @@ export async function deleteTransfer(transferId: string) {
 
   const transfer = await db.transfer.findFirst({
     where: { id: transferId, userId },
-    include: {
-      fromAccount: true,
-      toAccount: true,
+    select: {
+      id: true,
+      amount: true,
+      fromAccountId: true,
+      toAccountId: true,
+      fromAccount: { select: { name: true } },
+      toAccount: { select: { name: true } },
     },
   });
 
   if (!transfer) throw new Error("Transfer not found");
 
-  // Reverse the balance changes in a transaction
+  // Reverse the balance changes using atomic increments to avoid TOCTOU race conditions
   await db.$transaction(async (tx) => {
     await tx.transfer.delete({ where: { id: transferId } });
 
-    const restoredFromBalance = transfer.fromAccount.currentBalance + transfer.amount;
-    const restoredToBalance = transfer.toAccount.currentBalance - transfer.amount;
-
-    await tx.account.update({
+    const updatedFrom = await tx.account.update({
       where: { id: transfer.fromAccountId },
-      data: { currentBalance: restoredFromBalance },
+      data: { currentBalance: { increment: transfer.amount } },
     });
 
     await tx.balanceHistory.create({
       data: {
         accountId: transfer.fromAccountId,
-        balance: restoredFromBalance,
+        balance: updatedFrom.currentBalance,
         note: `Transfer reversal — to ${transfer.toAccount.name}`,
         date: new Date(),
       },
     });
 
-    await tx.account.update({
+    const updatedTo = await tx.account.update({
       where: { id: transfer.toAccountId },
-      data: { currentBalance: restoredToBalance },
+      data: { currentBalance: { increment: -transfer.amount } },
     });
 
     await tx.balanceHistory.create({
       data: {
         accountId: transfer.toAccountId,
-        balance: restoredToBalance,
+        balance: updatedTo.currentBalance,
         note: `Transfer reversal — from ${transfer.fromAccount.name}`,
         date: new Date(),
       },

--- a/lib/actions/transfers.ts
+++ b/lib/actions/transfers.ts
@@ -1,0 +1,184 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+
+export type CreateTransferInput = {
+  fromAccountId: string;
+  toAccountId: string;
+  amount: number;
+  note?: string;
+  date?: Date;
+};
+
+export type TransferWithAccounts = {
+  id: string;
+  userId: string;
+  fromAccountId: string;
+  toAccountId: string;
+  amount: number;
+  note: string | null;
+  date: Date;
+  createdAt: Date;
+  fromAccount: { id: string; name: string; type: string };
+  toAccount: { id: string; name: string; type: string };
+};
+
+export async function createTransfer(input: CreateTransferInput) {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Unauthorized");
+
+  if (input.fromAccountId === input.toAccountId) {
+    throw new Error("Source and destination accounts must be different");
+  }
+
+  if (input.amount <= 0) {
+    throw new Error("Transfer amount must be greater than zero");
+  }
+
+  // Verify both accounts belong to this user
+  const [fromAccount, toAccount] = await Promise.all([
+    db.account.findFirst({ where: { id: input.fromAccountId, userId, isActive: true } }),
+    db.account.findFirst({ where: { id: input.toAccountId, userId, isActive: true } }),
+  ]);
+
+  if (!fromAccount) throw new Error("Source account not found");
+  if (!toAccount) throw new Error("Destination account not found");
+
+  const transferDate = input.date ?? new Date();
+  const newFromBalance = fromAccount.currentBalance - input.amount;
+  const newToBalance = toAccount.currentBalance + input.amount;
+
+  // Execute all DB operations in a transaction
+  const transfer = await db.$transaction(async (tx) => {
+    const created = await tx.transfer.create({
+      data: {
+        userId,
+        fromAccountId: input.fromAccountId,
+        toAccountId: input.toAccountId,
+        amount: input.amount,
+        note: input.note,
+        date: transferDate,
+      },
+    });
+
+    await tx.account.update({
+      where: { id: input.fromAccountId },
+      data: { currentBalance: newFromBalance },
+    });
+
+    await tx.balanceHistory.create({
+      data: {
+        accountId: input.fromAccountId,
+        balance: newFromBalance,
+        note: `Transfer to ${toAccount.name}${input.note ? ` — ${input.note}` : ""}`,
+        date: transferDate,
+      },
+    });
+
+    await tx.account.update({
+      where: { id: input.toAccountId },
+      data: { currentBalance: newToBalance },
+    });
+
+    await tx.balanceHistory.create({
+      data: {
+        accountId: input.toAccountId,
+        balance: newToBalance,
+        note: `Transfer from ${fromAccount.name}${input.note ? ` — ${input.note}` : ""}`,
+        date: transferDate,
+      },
+    });
+
+    return created;
+  });
+
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
+
+  return transfer;
+}
+
+export async function getTransfers(options?: {
+  accountId?: string;
+  limit?: number;
+}) {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Unauthorized");
+
+  const where: Record<string, unknown> = { userId };
+
+  if (options?.accountId) {
+    where.OR = [
+      { fromAccountId: options.accountId },
+      { toAccountId: options.accountId },
+    ];
+  }
+
+  const transfers = await db.transfer.findMany({
+    where,
+    include: {
+      fromAccount: { select: { id: true, name: true, type: true } },
+      toAccount: { select: { id: true, name: true, type: true } },
+    },
+    orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+    take: options?.limit ?? 50,
+  });
+
+  return transfers as TransferWithAccounts[];
+}
+
+export async function deleteTransfer(transferId: string) {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Unauthorized");
+
+  const transfer = await db.transfer.findFirst({
+    where: { id: transferId, userId },
+    include: {
+      fromAccount: true,
+      toAccount: true,
+    },
+  });
+
+  if (!transfer) throw new Error("Transfer not found");
+
+  // Reverse the balance changes in a transaction
+  await db.$transaction(async (tx) => {
+    await tx.transfer.delete({ where: { id: transferId } });
+
+    const restoredFromBalance = transfer.fromAccount.currentBalance + transfer.amount;
+    const restoredToBalance = transfer.toAccount.currentBalance - transfer.amount;
+
+    await tx.account.update({
+      where: { id: transfer.fromAccountId },
+      data: { currentBalance: restoredFromBalance },
+    });
+
+    await tx.balanceHistory.create({
+      data: {
+        accountId: transfer.fromAccountId,
+        balance: restoredFromBalance,
+        note: `Transfer reversal — to ${transfer.toAccount.name}`,
+        date: new Date(),
+      },
+    });
+
+    await tx.account.update({
+      where: { id: transfer.toAccountId },
+      data: { currentBalance: restoredToBalance },
+    });
+
+    await tx.balanceHistory.create({
+      data: {
+        accountId: transfer.toAccountId,
+        balance: restoredToBalance,
+        note: `Transfer reversal — from ${transfer.fromAccount.name}`,
+        date: new Date(),
+      },
+    });
+  });
+
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
+}

--- a/prisma/migrations/20260401201429_transfer_on_delete_restrict/migration.sql
+++ b/prisma/migrations/20260401201429_transfer_on_delete_restrict/migration.sql
@@ -1,0 +1,170 @@
+-- CreateEnum
+CREATE TYPE "BillingCycle" AS ENUM ('ONCE', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY');
+
+-- CreateEnum
+CREATE TYPE "LoanStatus" AS ENUM ('PENDING', 'PARTIAL', 'COMPLETED');
+
+-- CreateEnum
+CREATE TYPE "AccountType" AS ENUM ('BANK', 'INVESTMENT', 'WALLET', 'CASH', 'CREDIT_CARD', 'DEBIT_CARD', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "Expense" ADD COLUMN     "accountId" TEXT,
+ADD COLUMN     "paymentMethod" TEXT,
+ADD COLUMN     "receiptUrls" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN     "dashboardWidgets" JSONB;
+
+-- CreateTable
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "billingCycle" "BillingCycle" NOT NULL DEFAULT 'MONTHLY',
+    "nextBillingDate" TIMESTAMP(3) NOT NULL,
+    "paymentMethod" TEXT,
+    "category" TEXT NOT NULL DEFAULT 'Subscription',
+    "description" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "alertDaysBefore" INTEGER NOT NULL DEFAULT 3,
+    "lastAlertSent" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Loan" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "borrowerName" TEXT NOT NULL,
+    "borrowerPhone" TEXT,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "amountRepaid" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "status" "LoanStatus" NOT NULL DEFAULT 'PENDING',
+    "lendDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dueDate" TIMESTAMP(3),
+    "description" TEXT,
+    "receiptUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Loan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Repayment" (
+    "id" TEXT NOT NULL,
+    "loanId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "note" TEXT,
+    "receiptUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Repayment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" "AccountType" NOT NULL DEFAULT 'BANK',
+    "currentBalance" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "description" TEXT,
+    "icon" TEXT,
+    "color" TEXT,
+    "creditLimit" DOUBLE PRECISION,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "showOnTelegram" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Transfer" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "fromAccountId" TEXT NOT NULL,
+    "toAccountId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "note" TEXT,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Transfer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BalanceHistory" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "balance" DOUBLE PRECISION NOT NULL,
+    "note" TEXT,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BalanceHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Subscription_userId_idx" ON "Subscription"("userId");
+
+-- CreateIndex
+CREATE INDEX "Subscription_nextBillingDate_idx" ON "Subscription"("nextBillingDate");
+
+-- CreateIndex
+CREATE INDEX "Loan_userId_idx" ON "Loan"("userId");
+
+-- CreateIndex
+CREATE INDEX "Loan_borrowerName_idx" ON "Loan"("borrowerName");
+
+-- CreateIndex
+CREATE INDEX "Repayment_loanId_idx" ON "Repayment"("loanId");
+
+-- CreateIndex
+CREATE INDEX "Account_userId_idx" ON "Account"("userId");
+
+-- CreateIndex
+CREATE INDEX "Account_type_idx" ON "Account"("type");
+
+-- CreateIndex
+CREATE INDEX "Transfer_userId_idx" ON "Transfer"("userId");
+
+-- CreateIndex
+CREATE INDEX "Transfer_fromAccountId_idx" ON "Transfer"("fromAccountId");
+
+-- CreateIndex
+CREATE INDEX "Transfer_toAccountId_idx" ON "Transfer"("toAccountId");
+
+-- CreateIndex
+CREATE INDEX "Transfer_date_idx" ON "Transfer"("date");
+
+-- CreateIndex
+CREATE INDEX "BalanceHistory_accountId_idx" ON "BalanceHistory"("accountId");
+
+-- CreateIndex
+CREATE INDEX "BalanceHistory_date_idx" ON "BalanceHistory"("date");
+
+-- CreateIndex
+CREATE INDEX "Expense_accountId_idx" ON "Expense"("accountId");
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Repayment" ADD CONSTRAINT "Repayment_loanId_fkey" FOREIGN KEY ("loanId") REFERENCES "Loan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transfer" ADD CONSTRAINT "Transfer_fromAccountId_fkey" FOREIGN KEY ("fromAccountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transfer" ADD CONSTRAINT "Transfer_toAccountId_fkey" FOREIGN KEY ("toAccountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BalanceHistory" ADD CONSTRAINT "BalanceHistory_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,8 +168,8 @@ model Transfer {
   amount        Float
   note          String?
   date          DateTime @default(now())
-  fromAccount   Account  @relation("TransferFrom", fields: [fromAccountId], references: [id], onDelete: Cascade)
-  toAccount     Account  @relation("TransferTo", fields: [toAccountId], references: [id], onDelete: Cascade)
+  fromAccount   Account  @relation("TransferFrom", fields: [fromAccountId], references: [id], onDelete: Restrict)
+  toAccount     Account  @relation("TransferTo", fields: [toAccountId], references: [id], onDelete: Restrict)
   createdAt     DateTime @default(now())
 
   @@index([userId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,9 +153,29 @@ model Account {
   updatedAt     DateTime        @updatedAt
   balanceHistory BalanceHistory[]
   expenses      Expense[]
+  transfersFrom Transfer[]      @relation("TransferFrom")
+  transfersTo   Transfer[]      @relation("TransferTo")
 
   @@index([userId])
   @@index([type])
+}
+
+model Transfer {
+  id            String   @id @default(uuid())
+  userId        String   // Clerk User ID
+  fromAccountId String
+  toAccountId   String
+  amount        Float
+  note          String?
+  date          DateTime @default(now())
+  fromAccount   Account  @relation("TransferFrom", fields: [fromAccountId], references: [id], onDelete: Cascade)
+  toAccount     Account  @relation("TransferTo", fields: [toAccountId], references: [id], onDelete: Cascade)
+  createdAt     DateTime @default(now())
+
+  @@index([userId])
+  @@index([fromAccountId])
+  @@index([toAccountId])
+  @@index([date])
 }
 
 model BalanceHistory {

--- a/tests/unit/actions/accounts.test.ts
+++ b/tests/unit/actions/accounts.test.ts
@@ -18,6 +18,9 @@ const mockDb = {
         delete: vi.fn(),
         deleteMany: vi.fn(),
     },
+    transfer: {
+        count: vi.fn(),
+    },
 };
 
 vi.mock("@/lib/db", () => ({
@@ -178,6 +181,7 @@ describe("Account Actions", () => {
                 id: "account-1",
                 userId: "test-user-id",
             });
+            mockDb.transfer.count.mockResolvedValue(0);
             mockDb.account.delete.mockResolvedValue({ id: "account-1" });
 
             vi.resetModules();

--- a/tests/unit/actions/transfers.test.ts
+++ b/tests/unit/actions/transfers.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFromAccount = {
+  id: "account-1",
+  userId: "test-user-id",
+  name: "SBI Savings",
+  type: "BANK",
+  currentBalance: 10000,
+  isActive: true,
+};
+
+const mockToAccount = {
+  id: "account-2",
+  userId: "test-user-id",
+  name: "HDFC Savings",
+  type: "BANK",
+  currentBalance: 5000,
+  isActive: true,
+};
+
+const mockTransfer = {
+  id: "transfer-1",
+  userId: "test-user-id",
+  fromAccountId: "account-1",
+  toAccountId: "account-2",
+  amount: 2000,
+  note: "Monthly savings move",
+  date: new Date("2026-04-01"),
+  createdAt: new Date(),
+};
+
+// Minimal mock for prisma transaction
+const txMock = {
+  transfer: {
+    create: vi.fn().mockResolvedValue(mockTransfer),
+    delete: vi.fn(),
+  },
+  account: {
+    update: vi.fn(),
+  },
+  balanceHistory: {
+    create: vi.fn(),
+  },
+};
+
+const mockDb = {
+  account: {
+    findFirst: vi.fn(),
+  },
+  transfer: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    delete: vi.fn(),
+  },
+  balanceHistory: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(async (fn: (tx: typeof txMock) => Promise<unknown>) => fn(txMock)),
+};
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(() => Promise.resolve({ userId: "test-user-id" })),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+describe("Transfer Actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.$transaction.mockImplementation(
+      async (fn: (tx: typeof txMock) => Promise<unknown>) => fn(txMock)
+    );
+    txMock.transfer.create.mockResolvedValue(mockTransfer);
+    txMock.account.update.mockResolvedValue({});
+    txMock.balanceHistory.create.mockResolvedValue({});
+    txMock.transfer.delete.mockResolvedValue({});
+  });
+
+  describe("createTransfer", () => {
+    it("should create a transfer and update both account balances", async () => {
+      mockDb.account.findFirst
+        .mockResolvedValueOnce(mockFromAccount)
+        .mockResolvedValueOnce(mockToAccount);
+
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      const result = await createTransfer({
+        fromAccountId: "account-1",
+        toAccountId: "account-2",
+        amount: 2000,
+        note: "Monthly savings move",
+      });
+
+      expect(result).toEqual(mockTransfer);
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+      expect(txMock.transfer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: "test-user-id",
+            fromAccountId: "account-1",
+            toAccountId: "account-2",
+            amount: 2000,
+          }),
+        })
+      );
+      // Both accounts should be updated
+      expect(txMock.account.update).toHaveBeenCalledTimes(2);
+      // From account deducted: 10000 - 2000 = 8000
+      expect(txMock.account.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "account-1" },
+          data: { currentBalance: 8000 },
+        })
+      );
+      // To account credited: 5000 + 2000 = 7000
+      expect(txMock.account.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "account-2" },
+          data: { currentBalance: 7000 },
+        })
+      );
+      // Balance history created for both accounts
+      expect(txMock.balanceHistory.create).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw when source and destination accounts are the same", async () => {
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-1", amount: 500 })
+      ).rejects.toThrow("Source and destination accounts must be different");
+
+      expect(mockDb.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("should throw when amount is zero or negative", async () => {
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-2", amount: 0 })
+      ).rejects.toThrow("Transfer amount must be greater than zero");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-2", amount: -100 })
+      ).rejects.toThrow("Transfer amount must be greater than zero");
+    });
+
+    it("should throw when source account is not found", async () => {
+      mockDb.account.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockToAccount);
+
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-2", amount: 500 })
+      ).rejects.toThrow("Source account not found");
+    });
+
+    it("should throw when destination account is not found", async () => {
+      mockDb.account.findFirst
+        .mockResolvedValueOnce(mockFromAccount)
+        .mockResolvedValueOnce(null);
+
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-2", amount: 500 })
+      ).rejects.toThrow("Destination account not found");
+    });
+
+    it("should throw for unauthenticated user", async () => {
+      const { auth } = await import("@clerk/nextjs/server");
+      vi.mocked(auth).mockResolvedValueOnce({ userId: null } as never);
+
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-2", amount: 500 })
+      ).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("getTransfers", () => {
+    it("should return transfers for the user", async () => {
+      const mockTransfers = [
+        {
+          ...mockTransfer,
+          fromAccount: { id: "account-1", name: "SBI Savings", type: "BANK" },
+          toAccount: { id: "account-2", name: "HDFC Savings", type: "BANK" },
+        },
+      ];
+
+      mockDb.transfer.findMany.mockResolvedValue(mockTransfers);
+
+      vi.resetModules();
+      const { getTransfers } = await import("@/lib/actions/transfers");
+      const result = await getTransfers();
+
+      expect(result).toEqual(mockTransfers);
+      expect(mockDb.transfer.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: "test-user-id" }),
+          include: expect.objectContaining({
+            fromAccount: expect.anything(),
+            toAccount: expect.anything(),
+          }),
+        })
+      );
+    });
+
+    it("should filter by accountId when provided", async () => {
+      mockDb.transfer.findMany.mockResolvedValue([]);
+
+      vi.resetModules();
+      const { getTransfers } = await import("@/lib/actions/transfers");
+      await getTransfers({ accountId: "account-1" });
+
+      expect(mockDb.transfer.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: [
+              { fromAccountId: "account-1" },
+              { toAccountId: "account-1" },
+            ],
+          }),
+        })
+      );
+    });
+  });
+
+  describe("deleteTransfer", () => {
+    it("should delete a transfer and reverse both account balances", async () => {
+      const transferWithAccounts = {
+        ...mockTransfer,
+        fromAccount: { ...mockFromAccount, currentBalance: 8000 },
+        toAccount: { ...mockToAccount, currentBalance: 7000 },
+      };
+
+      mockDb.transfer.findFirst.mockResolvedValue(transferWithAccounts);
+
+      vi.resetModules();
+      const { deleteTransfer } = await import("@/lib/actions/transfers");
+      await deleteTransfer("transfer-1");
+
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+      expect(txMock.transfer.delete).toHaveBeenCalledWith({ where: { id: "transfer-1" } });
+      // From account restored: 8000 + 2000 = 10000
+      expect(txMock.account.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "account-1" },
+          data: { currentBalance: 10000 },
+        })
+      );
+      // To account reversed: 7000 - 2000 = 5000
+      expect(txMock.account.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "account-2" },
+          data: { currentBalance: 5000 },
+        })
+      );
+    });
+
+    it("should throw when transfer is not found", async () => {
+      mockDb.transfer.findFirst.mockResolvedValue(null);
+
+      vi.resetModules();
+      const { deleteTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(deleteTransfer("bad-id")).rejects.toThrow("Transfer not found");
+    });
+  });
+});

--- a/tests/unit/actions/transfers.test.ts
+++ b/tests/unit/actions/transfers.test.ts
@@ -36,6 +36,7 @@ const txMock = {
     delete: vi.fn(),
   },
   account: {
+    findFirst: vi.fn(),
     update: vi.fn(),
   },
   balanceHistory: {
@@ -74,14 +75,15 @@ describe("Transfer Actions", () => {
       async (fn: (tx: typeof txMock) => Promise<unknown>) => fn(txMock)
     );
     txMock.transfer.create.mockResolvedValue(mockTransfer);
-    txMock.account.update.mockResolvedValue({});
+    txMock.account.findFirst.mockReset();
+    txMock.account.update.mockResolvedValue({ currentBalance: 0 });
     txMock.balanceHistory.create.mockResolvedValue({});
     txMock.transfer.delete.mockResolvedValue({});
   });
 
   describe("createTransfer", () => {
     it("should create a transfer and update both account balances", async () => {
-      mockDb.account.findFirst
+      txMock.account.findFirst
         .mockResolvedValueOnce(mockFromAccount)
         .mockResolvedValueOnce(mockToAccount);
 
@@ -107,20 +109,18 @@ describe("Transfer Actions", () => {
           }),
         })
       );
-      // Both accounts should be updated
+      // Both accounts should be updated with atomic increments
       expect(txMock.account.update).toHaveBeenCalledTimes(2);
-      // From account deducted: 10000 - 2000 = 8000
       expect(txMock.account.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "account-1" },
-          data: { currentBalance: 8000 },
+          data: { currentBalance: { increment: -2000 } },
         })
       );
-      // To account credited: 5000 + 2000 = 7000
       expect(txMock.account.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "account-2" },
-          data: { currentBalance: 7000 },
+          data: { currentBalance: { increment: 2000 } },
         })
       );
       // Balance history created for both accounts
@@ -152,7 +152,7 @@ describe("Transfer Actions", () => {
     });
 
     it("should throw when source account is not found", async () => {
-      mockDb.account.findFirst
+      txMock.account.findFirst
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(mockToAccount);
 
@@ -165,7 +165,7 @@ describe("Transfer Actions", () => {
     });
 
     it("should throw when destination account is not found", async () => {
-      mockDb.account.findFirst
+      txMock.account.findFirst
         .mockResolvedValueOnce(mockFromAccount)
         .mockResolvedValueOnce(null);
 
@@ -177,11 +177,26 @@ describe("Transfer Actions", () => {
       ).rejects.toThrow("Destination account not found");
     });
 
+    it("should throw when source account has insufficient funds", async () => {
+      txMock.account.findFirst
+        .mockResolvedValueOnce({ ...mockFromAccount, currentBalance: 100 })
+        .mockResolvedValueOnce(mockToAccount);
+
+      vi.resetModules();
+      const { createTransfer } = await import("@/lib/actions/transfers");
+
+      await expect(
+        createTransfer({ fromAccountId: "account-1", toAccountId: "account-2", amount: 500 })
+      ).rejects.toThrow("Insufficient funds");
+
+      expect(txMock.transfer.create).not.toHaveBeenCalled();
+    });
+
     it("should throw for unauthenticated user", async () => {
+      vi.resetModules();
       const { auth } = await import("@clerk/nextjs/server");
       vi.mocked(auth).mockResolvedValueOnce({ userId: null } as never);
 
-      vi.resetModules();
       const { createTransfer } = await import("@/lib/actions/transfers");
 
       await expect(
@@ -254,18 +269,18 @@ describe("Transfer Actions", () => {
 
       expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
       expect(txMock.transfer.delete).toHaveBeenCalledWith({ where: { id: "transfer-1" } });
-      // From account restored: 8000 + 2000 = 10000
+      // From account restored with atomic increment
       expect(txMock.account.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "account-1" },
-          data: { currentBalance: 10000 },
+          data: { currentBalance: { increment: 2000 } },
         })
       );
-      // To account reversed: 7000 - 2000 = 5000
+      // To account reversed with atomic increment
       expect(txMock.account.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "account-2" },
-          data: { currentBalance: 5000 },
+          data: { currentBalance: { increment: -2000 } },
         })
       );
     });


### PR DESCRIPTION
## PR Description
 
Adds end-to-end bank transfer support allowing users to move money between accounts.
 
### Features
- **Transfer dialog** ([components/bank-transfer-dialog.tsx](cci:7://file:///Users/sukhendu/Code/personal/chamber/components/bank-transfer-dialog.tsx:0:0-0:0)) — create transfers with account selection, amount, date, and optional note. Live balance preview and insufficient-funds validation.
- **Server actions** ([lib/actions/transfers.ts](cci:7://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:0:0-0:0)) — [createTransfer](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:27:0-102:1), [deleteTransfer](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:133:0-186:1), and [getTransfers](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:104:0-131:1) with proper auth and revalidation.
- **Prisma schema** — new `Transfer` model linking two accounts with relations `transfersFrom` / `transfersTo`. `BalanceHistory` entries are created for both sides of every transfer.
 
### Critical fixes included
- **TOCTOU race elimination** — all balance reads now happen inside the same transaction that updates them; updates use atomic `{ increment: ±amount }` instead of absolute values.
- **Server-side validation** — [createTransfer](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:27:0-102:1) rejects transfers exceeding available balance (previously only client-side).
- **Schema integrity** — changed `onDelete: Cascade` to `Restrict` on Transfer relations; [deleteAccount](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/accounts.ts:236:0-265:1) now blocks deletion if transfers exist to prevent orphaned balances on linked accounts.
 
### Tests
- Unit tests for [createTransfer](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:27:0-102:1), [getTransfers](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:104:0-131:1), [deleteTransfer](cci:1://file:///Users/sukhendu/Code/personal/chamber/lib/actions/transfers.ts:133:0-186:1) covering success paths, validation errors, auth failures, and insufficient funds.
 
### Migration required
Run `pnpm prisma migrate deploy` to apply `transfer_on_delete_restrict`.