### PR TITLE
feat(accounts): add option to exclude accounts from net worth

### DIFF
--- a/components/account-list.tsx
+++ b/components/account-list.tsx
@@ -60,6 +60,7 @@ import {
   IconQuestionMark,
   IconHistory,
   IconBrandTelegram,
+  IconCalculator,
 } from "@tabler/icons-react";
 import { 
   updateBalance, 
@@ -68,6 +69,7 @@ import {
   getAccountWithHistory,
   deleteBalanceHistory,
   toggleShowOnTelegram,
+  toggleIncludeInNetWorth,
 } from "@/lib/actions/accounts";
 
 type BalanceHistoryItem = {
@@ -86,6 +88,7 @@ type Account = {
   description: string | null;
   isActive: boolean;
   showOnTelegram: boolean;
+  includeInNetWorth: boolean;
   balanceHistory: BalanceHistoryItem[];
 };
 
@@ -326,6 +329,15 @@ export function AccountList({ accounts, currency }: AccountListProps) {
           <IconBrandTelegram className="mr-2 h-4 w-4" />
           {account.showOnTelegram ? "Hide from Telegram" : "Show on Telegram"}
         </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={async () => {
+            await toggleIncludeInNetWorth(account.id);
+            router.refresh();
+          }}
+        >
+          <IconCalculator className="mr-2 h-4 w-4" />
+          {account.includeInNetWorth ? "Exclude from Net Worth" : "Include in Net Worth"}
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="text-destructive"
@@ -393,6 +405,9 @@ export function AccountList({ accounts, currency }: AccountListProps) {
                       {account.showOnTelegram && (
                         <IconBrandTelegram className="h-3.5 w-3.5 shrink-0 text-blue-400" />
                       )}
+                      {!account.includeInNetWorth && (
+                        <IconCalculator className="h-3.5 w-3.5 shrink-0 text-muted-foreground" title="Excluded from Net Worth" />
+                      )}
                     </div>
                     {account.description && (
                       <div className="text-xs text-muted-foreground truncate">
@@ -449,6 +464,9 @@ export function AccountList({ accounts, currency }: AccountListProps) {
                           {account.name}
                           {account.showOnTelegram && (
                             <IconBrandTelegram className="h-3.5 w-3.5 text-blue-400" title="Visible on Telegram" />
+                          )}
+                          {!account.includeInNetWorth && (
+                            <IconCalculator className="h-3.5 w-3.5 text-muted-foreground" title="Excluded from Net Worth" />
                           )}
                         </div>
                         {account.description && (

--- a/lib/actions/accounts.ts
+++ b/lib/actions/accounts.ts
@@ -302,12 +302,31 @@ export async function toggleAccountActive(id: string) {
   revalidatePath("/dashboard");
 }
 
+export async function toggleIncludeInNetWorth(id: string) {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Unauthorized");
+
+  const account = await db.account.findFirst({
+    where: { id, userId },
+  });
+
+  if (!account) throw new Error("Account not found");
+
+  await db.account.update({
+    where: { id },
+    data: { includeInNetWorth: !account.includeInNetWorth },
+  });
+
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
+}
+
 export async function getAccountStats() {
   const { userId } = await auth();
   if (!userId) throw new Error("Unauthorized");
 
   const accounts = await db.account.findMany({
-    where: { userId, isActive: true },
+    where: { userId, isActive: true, includeInNetWorth: true },
   });
 
   let totalBankBalance = 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,6 +149,7 @@ model Account {
   creditLimit   Float?          // Credit limit (for CREDIT_CARD accounts)
   isActive      Boolean         @default(true)
   showOnTelegram Boolean        @default(true) // Whether to show in Telegram bot payment options
+  includeInNetWorth Boolean     @default(true) // Whether to include in net worth calculation
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
   balanceHistory BalanceHistory[]


### PR DESCRIPTION
## Summary
Adds the ability to exclude specific accounts from net worth/bank balance calculations while still tracking them.

## Changes
- **Database**: Added `includeInNetWorth` boolean field to Account model (default: `true`)
- **Server Action**: Updated `getAccountStats()` to filter by `includeInNetWorth: true`
- **Server Action**: Added `toggleIncludeInNetWorth(id: string)` to toggle the setting
- **UI**: Added toggle in account dropdown menu with calculator icon indicator

## Use Cases
- Exclude joint accounts from personal net worth
- Track business accounts separately
- Keep historical/frozen accounts in history but exclude from current totals

Closes #30