### PR TITLE
fix(telegram): verify account ownership before processing pay_callbacks

### DIFF
--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -243,13 +243,13 @@ async function handleAccountsCommand(chatId: number) {
 
   // Display accounts grouped by type
   const typeOrder = ["BANK", "INVESTMENT", "WALLET", "CASH", "CREDIT_CARD", "DEBIT_CARD", "OTHER"];
-  
+
   for (const type of typeOrder) {
     const typeAccounts = accountsByType[type];
     if (!typeAccounts || typeAccounts.length === 0) continue;
 
     const icon = ACCOUNT_TYPE_ICONS[type] || "💰";
-    
+
     for (const account of typeAccounts) {
       const balance = Number(account.currentBalance);
       totalBalance += balance;
@@ -818,9 +818,6 @@ export async function POST(request: NextRequest) {
           const accountId = data.replace("pay_", "");
           const pending = pendingExpenses.get(chatId);
           if (pending && pending.expiresAt > Date.now()) {
-            // Verify the account exists AND belongs to the pending expense's user
-            // This prevents callback_data manipulation attacks where a user could
-            // supply a foreign accountId to access or modify another user's account.
             const account = await db.account.findFirst({
               where: { id: accountId, userId: pending.userId },
             });

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -818,9 +818,23 @@ export async function POST(request: NextRequest) {
           const accountId = data.replace("pay_", "");
           const pending = pendingExpenses.get(chatId);
           if (pending && pending.expiresAt > Date.now()) {
-            // Look up the account to get name and type for balance adjustment
-            const account = await db.account.findUnique({ where: { id: accountId } });
-            const accountName = account?.name || accountId;
+            // Verify the account exists AND belongs to the pending expense's user
+            // This prevents callback_data manipulation attacks where a user could
+            // supply a foreign accountId to access or modify another user's account.
+            const account = await db.account.findFirst({
+              where: { id: accountId, userId: pending.userId },
+            });
+
+            if (!account) {
+              await editMessageText(
+                chatId,
+                messageId,
+                "❌ Account not found or access denied. Please try again."
+              );
+              await answerCallbackQuery(callbackQuery.id, "Account not found");
+              return NextResponse.json({ ok: true });
+            }
+            const accountName = account.name;
 
             // Save expense and adjust balance in a transaction
             await db.$transaction(async (tx) => {
@@ -840,22 +854,20 @@ export async function POST(request: NextRequest) {
               });
 
               // Adjust account balance and record history
-              if (account) {
-                const adjustment = getTelegramBalanceAdjustment(account.type, pending.amount);
-                const updatedAccount = await tx.account.update({
-                  where: { id: accountId },
-                  data: { currentBalance: { increment: adjustment } },
-                });
-                const label = pending.description || pending.category || "Expense";
-                await tx.balanceHistory.create({
-                  data: {
-                    accountId,
-                    balance: updatedAccount.currentBalance,
-                    note: `Expense: ${label} (₹${pending.amount})`,
-                    date: new Date(),
-                  },
-                });
-              }
+              const adjustment = getTelegramBalanceAdjustment(account.type, pending.amount);
+              const updatedAccount = await tx.account.update({
+                where: { id: accountId },
+                data: { currentBalance: { increment: adjustment } },
+              });
+              const label = pending.description || pending.category || "Expense";
+              await tx.balanceHistory.create({
+                data: {
+                  accountId,
+                  balance: updatedAccount.currentBalance,
+                  note: `Expense: ${label} (₹${pending.amount})`,
+                  date: new Date(),
+                },
+              });
             });
 
             // Notify web UI to refresh


### PR DESCRIPTION
Fixes #39

Previously, the webhook looked up accounts by ID alone via db.account.findUnique({ where: { id: accountId } }). A malicious user could manipulate the callback_data of an inline button to supply a foreign accountId and trigger balance adjustments on accounts they do not own.

The fix:
- Replaces findUnique with findFirst and adds userId: pending.userId to the where clause, scoping the lookup to the pending expense owner.
- Returns an explicit 'Account not found or access denied' response and exits early if the account is not found or belongs to another user.
- Removes the now-redundant if (account) guard inside the transaction and the optional chain on account?.name since account is guaranteed non-null after the early return check.

This aligns the webhook with the server action security pattern used throughout the rest of the codebase.