### PR TITLE
feat: add timezone support for dashboard date calculations

### DIFF
--- a/components/settings-form.tsx
+++ b/components/settings-form.tsx
@@ -36,6 +36,24 @@ const currencies = [
   { value: "GBP", label: "British Pound (£)" },
 ];
 
+const timezones = [
+  { value: "UTC", label: "UTC (Coordinated Universal Time)" },
+  { value: "Asia/Kolkata", label: "India (IST) - Asia/Kolkata" },
+  { value: "America/New_York", label: "Eastern Time (ET) - America/New_York" },
+  { value: "America/Chicago", label: "Central Time (CT) - America/Chicago" },
+  { value: "America/Denver", label: "Mountain Time (MT) - America/Denver" },
+  { value: "America/Los_Angeles", label: "Pacific Time (PT) - America/Los_Angeles" },
+  { value: "Europe/London", label: "London (GMT/BST) - Europe/London" },
+  { value: "Europe/Paris", label: "Paris (CET/CEST) - Europe/Paris" },
+  { value: "Europe/Berlin", label: "Berlin (CET/CEST) - Europe/Berlin" },
+  { value: "Asia/Tokyo", label: "Tokyo (JST) - Asia/Tokyo" },
+  { value: "Asia/Shanghai", label: "Shanghai (CST) - Asia/Shanghai" },
+  { value: "Asia/Singapore", label: "Singapore (SGT) - Asia/Singapore" },
+  { value: "Asia/Dubai", label: "Dubai (GST) - Asia/Dubai" },
+  { value: "Australia/Sydney", label: "Sydney (AEST/AEDT) - Australia/Sydney" },
+  { value: "Pacific/Auckland", label: "Auckland (NZST/NZDT) - Pacific/Auckland" },
+];
+
 const categories = [
   "Food",
   "Travel",
@@ -51,6 +69,7 @@ type SettingsFormProps = {
   initialSettings: {
     monthlyBudget: number;
     currency: string;
+    timezone: string;
     dashboardWidgets: DashboardWidgets;
   };
 };
@@ -60,6 +79,7 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
     initialSettings.monthlyBudget.toString()
   );
   const [currency, setCurrency] = useState(initialSettings.currency);
+  const [timezone, setTimezone] = useState(initialSettings.timezone || "Asia/Kolkata");
   const [dashboardWidgets, setDashboardWidgets] = useState<DashboardWidgets>(
     initialSettings.dashboardWidgets || DEFAULT_DASHBOARD_WIDGETS
   );
@@ -123,6 +143,7 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
       await updateUserSettings({
         monthlyBudget: parseFloat(monthlyBudget) || 0,
         currency,
+        timezone,
         dashboardWidgets,
       });
       setSaved(true);
@@ -168,6 +189,24 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
                 </SelectContent>
               </Select>
             </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="timezone">Timezone</Label>
+            <Select value={timezone} onValueChange={setTimezone}>
+              <SelectTrigger id="timezone">
+                <SelectValue placeholder="Select timezone" />
+              </SelectTrigger>
+              <SelectContent>
+                {timezones.map((tz) => (
+                  <SelectItem key={tz.value} value={tz.value}>
+                    {tz.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Used for calculating monthly expense periods correctly
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/lib/actions/expenses.ts
+++ b/lib/actions/expenses.ts
@@ -4,6 +4,8 @@ import { auth } from "@clerk/nextjs/server";
 import { db } from "@/lib/db";
 import { revalidatePath } from "next/cache";
 import { checkAndSendSubscriptionAlerts } from "@/lib/subscription-alerts";
+import { getUserSettings } from "@/lib/actions/settings";
+import { getNowInTimezone, getStartOfMonthInTimezone, getEndOfMonthInTimezone } from "@/lib/utils";
 
 export type CreateExpenseInput = {
   amount: number;
@@ -300,9 +302,14 @@ export async function getMonthlyStats() {
   const { userId } = await auth();
   if (!userId) throw new Error("Unauthorized");
 
-  const now = new Date();
-  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-  const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+  // Get user's timezone setting
+  const settings = await getUserSettings();
+  const userTimezone = settings.timezone || "UTC";
+
+  // Use user's timezone for date calculations
+  const now = getNowInTimezone(userTimezone);
+  const startOfMonth = getStartOfMonthInTimezone(userTimezone);
+  const endOfMonth = getEndOfMonthInTimezone(userTimezone);
 
   // Get expenses for current month (for stats)
   const monthlyExpenses = await db.expense.findMany({
@@ -376,7 +383,12 @@ export async function getAnalyticsData() {
   const { userId } = await auth();
   if (!userId) throw new Error("Unauthorized");
 
-  const now = new Date();
+  // Get user's timezone setting
+  const settings = await getUserSettings();
+  const userTimezone = settings.timezone || "UTC";
+
+  // Use user's timezone for date calculations
+  const now = getNowInTimezone(userTimezone);
 
   // Get expenses for the last 6 months
   const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 5, 1);
@@ -392,7 +404,7 @@ export async function getAnalyticsData() {
   });
 
   // Current month stats
-  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const startOfMonth = getStartOfMonthInTimezone(userTimezone);
   const currentMonthExpenses: typeof expenses = [];
   for (const exp of expenses) {
     if (new Date(exp.date) >= startOfMonth) {

--- a/lib/actions/settings.ts
+++ b/lib/actions/settings.ts
@@ -31,6 +31,7 @@ const getCachedSettings = unstable_cache(
           userId,
           monthlyBudget: 0,
           currency: "INR",
+          timezone: "Asia/Kolkata",
           dashboardWidgets: DEFAULT_DASHBOARD_WIDGETS,
         },
       });
@@ -61,6 +62,7 @@ export async function getUserSettings() {
 export async function updateUserSettings(input: {
   monthlyBudget?: number;
   currency?: string;
+  timezone?: string;
   dashboardWidgets?: DashboardWidgets;
 }) {
   const { userId } = await auth();
@@ -108,6 +110,7 @@ export async function updateUserSettings(input: {
       userId,
       monthlyBudget: input.monthlyBudget || 0,
       currency: input.currency || "INR",
+      timezone: input.timezone || "Asia/Kolkata",
     },
   });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,3 +12,42 @@ export function toLocalDateString(date: Date = new Date()): string {
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
+
+// Get current date in user's timezone
+export function getNowInTimezone(timezone: string): Date {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(now);
+  const partsMap = new Map(parts.map((p) => [p.type, p.value]));
+
+  const year = parseInt(partsMap.get("year") || "0", 10);
+  const month = parseInt(partsMap.get("month") || "0", 10) - 1; // 0-indexed
+  const day = parseInt(partsMap.get("day") || "0", 10);
+  const hour = parseInt(partsMap.get("hour") || "0", 10);
+  const minute = parseInt(partsMap.get("minute") || "0", 10);
+  const second = parseInt(partsMap.get("second") || "0", 10);
+
+  return new Date(year, month, day, hour, minute, second);
+}
+
+// Get start of month in user's timezone
+export function getStartOfMonthInTimezone(timezone: string): Date {
+  const now = getNowInTimezone(timezone);
+  return new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0);
+}
+
+// Get end of month in user's timezone
+export function getEndOfMonthInTimezone(timezone: string): Date {
+  const now = getNowInTimezone(timezone);
+  return new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model UserSettings {
   telegramChatId   String?  @unique // Linked Telegram Chat ID
   monthlyBudget    Float    @default(0)
   currency         String   @default("INR")
+  timezone         String   @default("Asia/Kolkata") // User's timezone for date calculations (default: IST for INR)
   dashboardWidgets Json?    // Stores which dashboard widgets to show/hide
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -30,6 +30,8 @@ vi.mock("next/navigation", () => ({
 // Mock next/cache
 vi.mock("next/cache", () => ({
     revalidatePath: vi.fn(),
+    revalidateTag: vi.fn(),
+    unstable_cache: vi.fn((fn: () => unknown) => fn),
 }));
 
 // Mock Clerk - always return authenticated user


### PR DESCRIPTION
- Add timezone field to UserSettings model (default: Asia/Kolkata/IST to match INR)
- Add timezone selection UI in settings form
- Create timezone-aware date utility functions (getNowInTimezone, getStartOfMonthInTimezone, getEndOfMonthInTimezone)
- Update getMonthlyStats to use user's timezone
- Update getAnalyticsData to use user's timezone

This fixes the issue where dashboard showed previous month's data when server timezone differed from user's timezone (e.g., on May 1st).