### PR TITLE
feat: add monthly income tracking for forecasting and calendar

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -248,6 +248,8 @@ export default async function DashboardPage() {
                 date: e.date,
               }))}
               currency={settings.currency}
+              monthlyIncome={settings.monthlyIncome || 0}
+              salaryDay={settings.salaryDay || 1}
             />
           )}
 

--- a/components/expense-calendar-widget.tsx
+++ b/components/expense-calendar-widget.tsx
@@ -23,9 +23,11 @@ type Expense = {
 type ExpenseCalendarWidgetProps = {
   expenses: Expense[];
   currency: string;
+  monthlyIncome?: number;
+  salaryDay?: number;
 };
 
-export function ExpenseCalendarWidget({ expenses, currency }: ExpenseCalendarWidgetProps) {
+export function ExpenseCalendarWidget({ expenses, currency, monthlyIncome = 0, salaryDay = 1 }: ExpenseCalendarWidgetProps) {
   const [currentDate, setCurrentDate] = useState(new Date());
 
   const formatCurrency = (amount: number) => {
@@ -101,6 +103,11 @@ export function ExpenseCalendarWidget({ expenses, currency }: ExpenseCalendarWid
     General: "bg-gray-500",
   };
 
+  // Check if a day is salary day for current month
+  const isSalaryDay = (day: number) => {
+    return monthlyIncome > 0 && day === salaryDay;
+  };
+
   // Generate calendar days
   const calendarDays = [];
 
@@ -117,33 +124,35 @@ export function ExpenseCalendarWidget({ expenses, currency }: ExpenseCalendarWid
     const dayTotal = getDayTotal(day);
     const today = isToday(day);
     const hasExpenses = dayExpenses.length > 0;
+    const salaryDayFlag = isSalaryDay(day);
 
     const dayCell = (
       <div
         className={`h-10 flex flex-col items-center justify-center relative cursor-pointer ${
-          today ? "bg-primary/10 rounded-full" : hasExpenses ? "hover:bg-muted/50 rounded" : ""
+          today ? "bg-primary/10 rounded-full" : salaryDayFlag ? "bg-green-500/10 rounded" : hasExpenses ? "hover:bg-muted/50 rounded" : ""
         }`}
       >
-        <span className={`text-xs ${today ? "font-bold text-primary" : hasExpenses ? "font-medium" : "text-muted-foreground"}`}>
+        <span className={`text-xs ${today ? "font-bold text-primary" : salaryDayFlag ? "font-bold text-green-600" : hasExpenses ? "font-medium" : "text-muted-foreground"}`}>
           {day}
         </span>
-        {hasExpenses && (
-          <div className="flex gap-0.5 mt-0.5">
-            {dayExpenses.slice(0, 3).map((exp, idx) => (
-              <div
-                key={idx}
-                className={`w-1 h-1 rounded-full ${categoryColors[exp.category] || "bg-gray-500"}`}
-              />
-            ))}
-            {dayExpenses.length > 3 && (
-              <span className="text-[8px] text-muted-foreground">+</span>
-            )}
-          </div>
-        )}
+        <div className="flex gap-0.5 mt-0.5">
+          {salaryDayFlag && (
+            <div className="w-1 h-1 rounded-full bg-green-500" title="Salary" />
+          )}
+          {dayExpenses.slice(0, 3).map((exp, idx) => (
+            <div
+              key={idx}
+              className={`w-1 h-1 rounded-full ${categoryColors[exp.category] || "bg-gray-500"}`}
+            />
+          ))}
+          {dayExpenses.length > 3 && (
+            <span className="text-[8px] text-muted-foreground">+</span>
+          )}
+        </div>
       </div>
     );
 
-    if (hasExpenses) {
+    if (hasExpenses || salaryDayFlag) {
       calendarDays.push(
         <Tooltip key={day}>
           <TooltipTrigger asChild>
@@ -154,6 +163,12 @@ export function ExpenseCalendarWidget({ expenses, currency }: ExpenseCalendarWid
               <div className="font-medium text-xs border-b pb-1 mb-1">
                 {day} {monthNames[month]} - {formatCurrency(dayTotal)}
               </div>
+              {salaryDayFlag && (
+                <div className="flex justify-between gap-2 text-xs text-green-600 font-medium">
+                  <span>💰 Salary</span>
+                  <span>+{formatCurrency(monthlyIncome)}</span>
+                </div>
+              )}
               {dayExpenses.slice(0, 5).map((exp, idx) => (
                 <div key={idx} className="flex justify-between gap-2 text-xs">
                   <span className="truncate">{exp.merchant || exp.description || exp.category}</span>
@@ -212,8 +227,20 @@ export function ExpenseCalendarWidget({ expenses, currency }: ExpenseCalendarWid
           <div className="grid grid-cols-7">{calendarDays}</div>
           {/* Month total */}
           <div className="mt-3 pt-3 border-t flex justify-between items-center">
-            <span className="text-xs text-muted-foreground">Month Total</span>
-            <span className="text-sm font-bold">{formatCurrency(monthTotal)}</span>
+            <div className="flex flex-col">
+              <span className="text-xs text-muted-foreground">Month Total</span>
+              {monthlyIncome > 0 && (
+                <span className="text-xs text-green-600">Income: +{formatCurrency(monthlyIncome)}</span>
+              )}
+            </div>
+            <div className="flex flex-col items-end">
+              <span className="text-sm font-bold">{formatCurrency(monthTotal)}</span>
+              {monthlyIncome > 0 && (
+                <span className={`text-xs font-medium ${monthlyIncome - monthTotal >= 0 ? "text-green-600" : "text-red-600"}`}>
+                  Net: {formatCurrency(monthlyIncome - monthTotal)}
+                </span>
+              )}
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/components/settings-form.tsx
+++ b/components/settings-form.tsx
@@ -73,6 +73,8 @@ type SettingsFormProps = {
     dashboardWidgets: DashboardWidgets;
     forecastHorizonMonths: number;
     savingsTargetPercent: number;
+    monthlyIncome: number;
+    salaryDay: number;
   };
 };
 
@@ -90,6 +92,12 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
   );
   const [savingsTargetPercent, setSavingsTargetPercent] = useState(
     initialSettings.savingsTargetPercent?.toString() || "20"
+  );
+  const [monthlyIncome, setMonthlyIncome] = useState(
+    initialSettings.monthlyIncome?.toString() || "0"
+  );
+  const [salaryDay, setSalaryDay] = useState(
+    initialSettings.salaryDay?.toString() || "1"
   );
   const [loading, setLoading] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -158,6 +166,8 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
         dashboardWidgets,
         forecastHorizonMonths: horizon,
         savingsTargetPercent: savings,
+        monthlyIncome: parseFloat(monthlyIncome) || 0,
+        salaryDay: parseInt(salaryDay) || 1,
       });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
@@ -188,6 +198,21 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
               />
             </div>
             <div className="space-y-2">
+              <Label htmlFor="monthly-income">Monthly Income</Label>
+              <Input
+                id="monthly-income"
+                type="number"
+                value={monthlyIncome}
+                onChange={(e) => setMonthlyIncome(e.target.value)}
+                placeholder="Enter your monthly income (salary)"
+              />
+              <p className="text-xs text-muted-foreground">
+                Used for forecasting and calendar salary markers
+              </p>
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
               <Label htmlFor="currency">Currency</Label>
               <Select value={currency} onValueChange={setCurrency}>
                 <SelectTrigger>
@@ -201,6 +226,21 @@ export function SettingsForm({ initialSettings }: SettingsFormProps) {
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="salary-day">Salary Day</Label>
+              <Input
+                id="salary-day"
+                type="number"
+                min="1"
+                max="28"
+                value={salaryDay}
+                onChange={(e) => setSalaryDay(e.target.value)}
+                placeholder="1"
+              />
+              <p className="text-xs text-muted-foreground">
+                Day of month you receive salary (1-28)
+              </p>
             </div>
           </div>
           <div className="space-y-2">

--- a/lib/actions/forecasting.ts
+++ b/lib/actions/forecasting.ts
@@ -39,6 +39,7 @@ interface ForecastInputs {
   trendSlope: number;
   monthlyRecurringTotal: number;
   monthlyGoalContribution: number;
+  monthlyIncome: number;
   horizonMonths: number;
 }
 
@@ -134,12 +135,15 @@ async function getForecastInputs(userId: string): Promise<ForecastInputs> {
     return sum + remaining / monthsRemaining;
   }, 0);
 
+  const monthlyIncome = settings.monthlyIncome || 0;
+
   return {
     currentTotalBalance,
     estimatedMonthlyExpense,
     trendSlope: trend.slope,
     monthlyRecurringTotal,
     monthlyGoalContribution,
+    monthlyIncome,
     horizonMonths,
   };
 }
@@ -154,6 +158,7 @@ function projectBalances(
     estimatedMonthlyExpense,
     trendSlope,
     monthlyGoalContribution,
+    monthlyIncome,
     horizonMonths,
   } = inputs;
 
@@ -163,6 +168,7 @@ function projectBalances(
   for (let i = 1; i <= horizonMonths; i++) {
     const trendAdjustment = trendSlope * i;
     const projectedExpense = (estimatedMonthlyExpense + trendAdjustment * 0.3) * spendingMultiplier;
+    balance += monthlyIncome;
     balance -= projectedExpense;
     balance -= monthlyGoalContribution;
     balances.push(Math.round(balance * 100) / 100);

--- a/lib/actions/settings.ts
+++ b/lib/actions/settings.ts
@@ -23,6 +23,8 @@ const UpdateUserSettingsSchema = z.object({
   dashboardWidgets: DashboardWidgetsSchema,
   forecastHorizonMonths: z.number().int().positive().optional(),
   savingsTargetPercent: z.number().nonnegative().max(100).optional(),
+  monthlyIncome: z.number().nonnegative().optional(),
+  salaryDay: z.number().int().min(1).max(28).optional(),
 });
 
 // Free exchange rate API (no API key needed for basic usage)
@@ -54,6 +56,8 @@ const getCachedSettings = unstable_cache(
           dashboardWidgets: DEFAULT_DASHBOARD_WIDGETS,
           forecastHorizonMonths: 6,
           savingsTargetPercent: 20,
+          monthlyIncome: 0,
+          salaryDay: 1,
         },
       });
     }
@@ -87,6 +91,8 @@ export async function updateUserSettings(input: {
   dashboardWidgets?: DashboardWidgets;
   forecastHorizonMonths?: number;
   savingsTargetPercent?: number;
+  monthlyIncome?: number;
+  salaryDay?: number;
 }) {
   const { userId } = await auth();
   if (!userId) throw new Error("Unauthorized");
@@ -138,6 +144,8 @@ export async function updateUserSettings(input: {
       timezone: validated.timezone || "Asia/Kolkata",
       forecastHorizonMonths: validated.forecastHorizonMonths || 6,
       savingsTargetPercent: validated.savingsTargetPercent || 20,
+      monthlyIncome: validated.monthlyIncome || 0,
+      salaryDay: validated.salaryDay || 1,
     },
   });
 
@@ -307,6 +315,8 @@ export async function deleteAllUserData() {
     where: { userId },
     data: {
       monthlyBudget: 0,
+      monthlyIncome: 0,
+      salaryDay: 1,
       telegramChatId: null,
     },
   });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,8 @@ model UserSettings {
   dashboardWidgets      Json?    // Stores which dashboard widgets to show/hide
   forecastHorizonMonths Int      @default(6) // Months to project forward
   savingsTargetPercent  Float    @default(20) // Target % of income to save
+  monthlyIncome         Float    @default(0) // User's monthly cash inflow (salary, etc.)
+  salaryDay             Int      @default(1) // Day of month salary arrives (1-28)
   createdAt             DateTime @default(now())
   updatedAt             DateTime @updatedAt
 

--- a/tests/unit/actions/forecasting.test.ts
+++ b/tests/unit/actions/forecasting.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock database client
+const mockDb = {
+  account: {
+    findMany: vi.fn(),
+  },
+  expense: {
+    findMany: vi.fn(),
+  },
+  recurringPattern: {
+    findMany: vi.fn(),
+  },
+  goal: {
+    findMany: vi.fn(),
+  },
+  userSettings: {
+    findUnique: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn().mockResolvedValue({ userId: "test-user-id" }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  unstable_cache: vi.fn((fn: () => unknown) => fn),
+}));
+
+vi.mock("@/lib/actions/settings", () => ({
+  getUserSettings: vi.fn().mockResolvedValue({
+    monthlyIncome: 50000,
+    salaryDay: 1,
+    forecastHorizonMonths: 6,
+    currency: "INR",
+    timezone: "Asia/Kolkata",
+  }),
+}));
+
+describe("Forecasting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDb.account.findMany.mockResolvedValue([
+      { currentBalance: 100000, isActive: true, includeInNetWorth: true },
+    ]);
+    mockDb.expense.findMany.mockResolvedValue([]);
+    mockDb.recurringPattern.findMany.mockResolvedValue([]);
+    mockDb.goal.findMany.mockResolvedValue([]);
+    mockDb.userSettings.findUnique.mockResolvedValue({
+      monthlyIncome: 50000,
+      salaryDay: 1,
+      forecastHorizonMonths: 6,
+    });
+  });
+
+  describe("getForecastData", () => {
+    it("should include monthly income in forecast projections", async () => {
+      const { getForecastData } = await import("@/lib/actions/forecasting");
+      const result = await getForecastData();
+
+      // With 100k balance, 50k monthly income, and no expenses,
+      // balance should increase by 50k each month
+      expect(result.projectedBalances[0]).toBe(150000);
+      expect(result.projectedBalances[5]).toBe(400000);
+    });
+
+    it("should factor income into optimistic and pessimistic scenarios", async () => {
+      const { getForecastData } = await import("@/lib/actions/forecasting");
+      const result = await getForecastData();
+
+      // With no expenses, optimistic and pessimistic should equal projected
+      expect(result.optimisticBalances[0]).toBe(result.projectedBalances[0]);
+      expect(result.pessimisticBalances[0]).toBe(result.projectedBalances[0]);
+    });
+
+    it("should offset expenses against income when expenses exist", async () => {
+      // Create 6 months of expenses at 30k/month
+      const now = new Date();
+      const expenses = [];
+      for (let i = 0; i < 6; i++) {
+        const monthStart = new Date(now.getFullYear(), now.getMonth() - 5 + i, 1);
+        expenses.push({
+          amount: 30000,
+          date: monthStart,
+          category: "Bills",
+          merchant: "Rent",
+          description: "Monthly rent",
+        });
+      }
+      mockDb.expense.findMany.mockResolvedValue(expenses);
+
+      const { getForecastData } = await import("@/lib/actions/forecasting");
+      const result = await getForecastData();
+
+      // With 50k income and 30k expenses, net +20k/month
+      // Starting at 100k: 100k + 50k - 30k = 120k after month 1
+      expect(result.projectedBalances[0]).toBe(120000);
+    });
+  });
+});


### PR DESCRIPTION
Add monthlyIncome and salaryDay fields to UserSettings schema, integrate income into forecast projections (balance += monthlyIncome per month), show salary day marker on expense calendar with green highlight and tooltip, display income/net in calendar footer, and add settings UI inputs for both fields.