### PR TITLE
feat: add tag support for expenses

### DIFF
--- a/app/(dashboard)/expenses/page.tsx
+++ b/app/(dashboard)/expenses/page.tsx
@@ -3,7 +3,7 @@ import { AddExpenseDialog } from "@/components/add-expense-dialog";
 import { ExpenseTable } from "@/components/expense-table";
 import { ExpenseFilters } from "@/components/expense-filters";
 import { Pagination } from "@/components/pagination";
-import { getExpenses, getExpensesCount } from "@/lib/actions/expenses";
+import { getExpenses, getExpensesCount, getUserTags } from "@/lib/actions/expenses";
 import { getUserSettings } from "@/lib/actions/settings";
 import { getAccounts } from "@/lib/actions/accounts";
 
@@ -22,7 +22,7 @@ export default async function ExpensesPage({
   const tag = params.tag || "";
   const offset = (page - 1) * ITEMS_PER_PAGE;
 
-  const [expenses, { count: totalCount, totalAmount }, settings, accounts] = await Promise.all([
+  const [expenses, { count: totalCount, totalAmount }, settings, accounts, allTags] = await Promise.all([
     getExpenses({
       limit: ITEMS_PER_PAGE,
       offset,
@@ -39,6 +39,7 @@ export default async function ExpensesPage({
     }),
     getUserSettings(),
     getAccounts(),
+    getUserTags(),
   ]);
 
   const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
@@ -70,6 +71,7 @@ export default async function ExpensesPage({
         currentCategory={category}
         currentExcludeCategory={excludeCategory}
         currentTag={tag}
+        allTags={allTags}
       />
 
       {/* Expenses Table */}

--- a/app/(dashboard)/expenses/page.tsx
+++ b/app/(dashboard)/expenses/page.tsx
@@ -12,13 +12,14 @@ const ITEMS_PER_PAGE = 10;
 export default async function ExpensesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; search?: string; category?: string; excludeCategory?: string }>;
+  searchParams: Promise<{ page?: string; search?: string; category?: string; excludeCategory?: string; tag?: string }>;
 }) {
   const params = await searchParams;
   const page = parseInt(params.page || "1", 10);
   const search = params.search || "";
   const category = params.category || "";
   const excludeCategory = params.excludeCategory || "";
+  const tag = params.tag || "";
   const offset = (page - 1) * ITEMS_PER_PAGE;
 
   const [expenses, { count: totalCount, totalAmount }, settings, accounts] = await Promise.all([
@@ -28,11 +29,13 @@ export default async function ExpensesPage({
       search: search || undefined,
       category: category || undefined,
       excludeCategory: excludeCategory || undefined,
+      tag: tag || undefined,
     }),
     getExpensesCount({
       search: search || undefined,
       category: category || undefined,
       excludeCategory: excludeCategory || undefined,
+      tag: tag || undefined,
     }),
     getUserSettings(),
     getAccounts(),
@@ -66,13 +69,14 @@ export default async function ExpensesPage({
         currentSearch={search}
         currentCategory={category}
         currentExcludeCategory={excludeCategory}
+        currentTag={tag}
       />
 
       {/* Expenses Table */}
       <Card className="border">
         <CardHeader>
           <CardTitle className="text-sm font-medium">
-            {search || category || excludeCategory
+            {search || category || excludeCategory || tag
               ? `Filtered Expenses (${totalCount}) - ${formatCurrency(totalAmount)}`
               : `All Expenses (${totalCount}) - ${formatCurrency(totalAmount)}`}
           </CardTitle>
@@ -88,13 +92,14 @@ export default async function ExpensesPage({
                   search={search}
                   category={category}
                   excludeCategory={excludeCategory}
+                  tag={tag}
                 />
               )}
             </>
           ) : (
             <div className="flex h-48 items-center justify-center">
               <p className="text-sm text-muted-foreground">
-                {search || category || excludeCategory
+                {search || category || excludeCategory || tag
                   ? "No expenses match your filters."
                   : "No expenses yet. Add your first expense to get started."}
               </p>

--- a/components/add-expense-dialog.tsx
+++ b/components/add-expense-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toLocalDateString } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -20,8 +20,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { TagInput } from "@/components/tag-input";
 import { IconPlus, IconUpload, IconX } from "@tabler/icons-react";
 import { createExpense } from "@/lib/actions/expenses";
+import { getUserTags } from "@/lib/actions/expenses";
 import { createSubscription } from "@/lib/actions/subscriptions";
 
 type AccountOption = {
@@ -71,6 +73,15 @@ export function AddExpenseDialog({ accounts = [] }: AddExpenseDialogProps) {
   // Derive account name for display/label
   const selectedAccountName = accounts.find(a => a.id === selectedAccountId)?.name;
   const [receipt, setReceipt] = useState<File | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagSuggestions, setTagSuggestions] = useState<string[]>([]);
+  
+  // Fetch existing tags when dialog opens
+  useEffect(() => {
+    if (open) {
+      getUserTags().then(setTagSuggestions);
+    }
+  }, [open]);
   
   // Subscription-specific fields
   const [billingCycle, setBillingCycle] = useState<"ONCE" | "WEEKLY" | "MONTHLY" | "QUARTERLY" | "YEARLY">("MONTHLY");
@@ -117,6 +128,7 @@ export function AddExpenseDialog({ accounts = [] }: AddExpenseDialogProps) {
           date: new Date(date),
           paymentMethod: selectedAccountName || undefined,
           accountId: selectedAccountId || undefined,
+          tags: tags.length > 0 ? tags : undefined,
         });
 
         // If there's a receipt, upload it
@@ -149,6 +161,7 @@ export function AddExpenseDialog({ accounts = [] }: AddExpenseDialogProps) {
     setDate(toLocalDateString());
     setSelectedAccountId("");
     setReceipt(null);
+    setTags([]);
     setBillingCycle("MONTHLY");
     setAlertDaysBefore("3");
   };
@@ -220,6 +233,16 @@ export function AddExpenseDialog({ accounts = [] }: AddExpenseDialogProps) {
               placeholder={isSubscription ? "Notes about this subscription" : "What was this expense for?"}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          
+          <div className="space-y-2">
+            <Label>Tags</Label>
+            <TagInput
+              value={tags}
+              onChange={setTags}
+              suggestions={tagSuggestions}
+              placeholder="Add keywords..."
             />
           </div>
           

--- a/components/expense-filters.tsx
+++ b/components/expense-filters.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useState, useRef, useTransition } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -12,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { IconSearch, IconX, IconTag } from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
 
 const categories = [
   "All",
@@ -32,6 +34,7 @@ type ExpenseFiltersProps = {
   currentCategory: string;
   currentExcludeCategory?: string;
   currentTag?: string;
+  allTags?: string[];
 };
 
 export function ExpenseFilters({
@@ -39,12 +42,22 @@ export function ExpenseFilters({
   currentCategory,
   currentExcludeCategory,
   currentTag = "",
+  allTags = [],
 }: ExpenseFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState(currentSearch);
   const [tag, setTag] = useState(currentTag);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const tagInputRef = useRef<HTMLInputElement>(null);
+
+  const filteredSuggestions = allTags.filter(
+    (t) =>
+      t.toLowerCase().includes(tag.toLowerCase()) &&
+      t !== tag,
+  );
 
   const updateFilters = (
     newSearch: string,
@@ -82,6 +95,13 @@ export function ExpenseFilters({
     });
   };
 
+  const selectTag = (selectedTag: string) => {
+    setTag(selectedTag);
+    setShowSuggestions(false);
+    setHighlightedIndex(-1);
+    updateFilters(search, currentCategory, selectedTag);
+  };
+
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     updateFilters(search, currentCategory, tag);
@@ -93,11 +113,33 @@ export function ExpenseFilters({
 
   const handleTagChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTag(e.target.value);
+    setShowSuggestions(true);
+    setHighlightedIndex(-1);
   };
 
-  const handleTagSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    updateFilters(search, currentCategory, tag);
+  const handleTagKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && filteredSuggestions[highlightedIndex]) {
+        selectTag(filteredSuggestions[highlightedIndex]);
+      } else {
+        setShowSuggestions(false);
+        updateFilters(search, currentCategory, tag);
+      }
+    } else if (e.key === "ArrowDown" && filteredSuggestions.length > 0) {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < filteredSuggestions.length - 1 ? prev + 1 : 0,
+      );
+    } else if (e.key === "ArrowUp" && filteredSuggestions.length > 0) {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev > 0 ? prev - 1 : filteredSuggestions.length - 1,
+      );
+    } else if (e.key === "Escape") {
+      setShowSuggestions(false);
+      setHighlightedIndex(-1);
+    }
   };
 
   const clearFilters = () => {
@@ -112,65 +154,131 @@ export function ExpenseFilters({
     currentSearch || currentCategory || currentExcludeCategory || currentTag;
 
   return (
-    <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
-      <form onSubmit={handleSearch} className="flex items-center gap-2">
-        <div className="relative flex-1 sm:flex-initial">
-          <IconSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            placeholder="Search expenses..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-9 sm:w-64"
-          />
-        </div>
-        <Button type="submit" variant="secondary" disabled={isPending}>
-          Search
-        </Button>
-      </form>
-
-      <div className="flex items-center gap-3">
-        <Select
-          value={currentCategory || "All"}
-          onValueChange={handleCategoryChange}
-        >
-          <SelectTrigger className="w-40">
-            <SelectValue placeholder="Category" />
-          </SelectTrigger>
-          <SelectContent>
-            {categories.map((cat) => (
-              <SelectItem key={cat} value={cat}>
-                {cat}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <form onSubmit={handleTagSubmit} className="flex items-center gap-2">
+    <div className="mb-6 space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+        <form onSubmit={handleSearch} className="flex items-center gap-2">
           <div className="relative flex-1 sm:flex-initial">
-            <IconTag className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <IconSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="text"
-              placeholder="Filter by tag..."
-              value={tag}
-              onChange={handleTagChange}
-              className="w-full pl-7 sm:w-36"
+              placeholder="Search expenses..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-9 sm:w-64"
             />
           </div>
+          <Button type="submit" variant="secondary" disabled={isPending}>
+            Search
+          </Button>
         </form>
 
-        {hasFilters && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={clearFilters}
-            disabled={isPending}
+        <div className="flex items-center gap-3">
+          <Select
+            value={currentCategory || "All"}
+            onValueChange={handleCategoryChange}
           >
-            <IconX className="mr-1 h-4 w-4" />
-            Clear
-          </Button>
-        )}
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map((cat) => (
+                <SelectItem key={cat} value={cat}>
+                  {cat}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="relative">
+            <div className="relative">
+              <IconTag className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                ref={tagInputRef}
+                type="text"
+                placeholder="Filter by tag..."
+                value={tag}
+                onChange={handleTagChange}
+                onKeyDown={handleTagKeyDown}
+                onFocus={() => {
+                  if (tag || allTags.length > 0) setShowSuggestions(true);
+                }}
+                onBlur={() => {
+                  setTimeout(() => {
+                    setShowSuggestions(false);
+                    setHighlightedIndex(-1);
+                  }, 150);
+                }}
+                className="w-full pl-7 sm:w-36"
+              />
+            </div>
+            {showSuggestions && filteredSuggestions.length > 0 && (
+              <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-32 overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
+                {filteredSuggestions.map((suggestion, index) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs",
+                      index === highlightedIndex
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted",
+                    )}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      selectTag(suggestion);
+                    }}
+                    onMouseEnter={() => setHighlightedIndex(index)}
+                  >
+                    <IconTag className="h-3 w-3 text-muted-foreground" />
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {hasFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearFilters}
+              disabled={isPending}
+            >
+              <IconX className="mr-1 h-4 w-4" />
+              Clear
+            </Button>
+          )}
+        </div>
       </div>
+
+      {allTags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Tags:</span>
+          {allTags.map((t) => (
+            <Badge
+              key={t}
+              variant={t === currentTag ? "default" : "secondary"}
+              className={cn(
+                "cursor-pointer text-[11px] px-2 py-0.5 transition-colors",
+                t === currentTag
+                  ? "hover:bg-primary/90"
+                  : "hover:bg-secondary/80",
+              )}
+              onClick={() => {
+                if (t === currentTag) {
+                  setTag("");
+                  updateFilters(search, currentCategory, "");
+                } else {
+                  setTag(t);
+                  updateFilters(search, currentCategory, t);
+                }
+              }}
+            >
+              {t}
+            </Badge>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/expense-filters.tsx
+++ b/components/expense-filters.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { IconSearch, IconX } from "@tabler/icons-react";
+import { IconSearch, IconX, IconTag } from "@tabler/icons-react";
 
 const categories = [
   "All",
@@ -31,15 +31,26 @@ type ExpenseFiltersProps = {
   currentSearch: string;
   currentCategory: string;
   currentExcludeCategory?: string;
+  currentTag?: string;
 };
 
-export function ExpenseFilters({ currentSearch, currentCategory, currentExcludeCategory }: ExpenseFiltersProps) {
+export function ExpenseFilters({
+  currentSearch,
+  currentCategory,
+  currentExcludeCategory,
+  currentTag = "",
+}: ExpenseFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState(currentSearch);
+  const [tag, setTag] = useState(currentTag);
 
-  const updateFilters = (newSearch: string, newCategory: string) => {
+  const updateFilters = (
+    newSearch: string,
+    newCategory: string,
+    newTag: string,
+  ) => {
     const params = new URLSearchParams(searchParams.toString());
 
     if (newSearch) {
@@ -50,7 +61,6 @@ export function ExpenseFilters({ currentSearch, currentCategory, currentExcludeC
 
     if (newCategory && newCategory !== "All") {
       params.set("category", newCategory);
-      // Optional: remove excludeCategory if a specific category is chosen
       params.delete("excludeCategory");
     } else {
       params.delete("category");
@@ -59,7 +69,12 @@ export function ExpenseFilters({ currentSearch, currentCategory, currentExcludeC
       }
     }
 
-    // Reset to page 1 when filters change
+    if (newTag) {
+      params.set("tag", newTag);
+    } else {
+      params.delete("tag");
+    }
+
     params.delete("page");
 
     startTransition(() => {
@@ -69,21 +84,32 @@ export function ExpenseFilters({ currentSearch, currentCategory, currentExcludeC
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    updateFilters(search, currentCategory);
+    updateFilters(search, currentCategory, tag);
   };
 
   const handleCategoryChange = (value: string) => {
-    updateFilters(search, value);
+    updateFilters(search, value, tag);
+  };
+
+  const handleTagChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTag(e.target.value);
+  };
+
+  const handleTagSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateFilters(search, currentCategory, tag);
   };
 
   const clearFilters = () => {
     setSearch("");
+    setTag("");
     startTransition(() => {
       router.push("/expenses");
     });
   };
 
-  const hasFilters = currentSearch || currentCategory || currentExcludeCategory;
+  const hasFilters =
+    currentSearch || currentCategory || currentExcludeCategory || currentTag;
 
   return (
     <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
@@ -119,6 +145,19 @@ export function ExpenseFilters({ currentSearch, currentCategory, currentExcludeC
             ))}
           </SelectContent>
         </Select>
+
+        <form onSubmit={handleTagSubmit} className="flex items-center gap-2">
+          <div className="relative flex-1 sm:flex-initial">
+            <IconTag className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Filter by tag..."
+              value={tag}
+              onChange={handleTagChange}
+              className="w-full pl-7 sm:w-36"
+            />
+          </div>
+        </form>
 
         {hasFilters && (
           <Button

--- a/components/expense-table.tsx
+++ b/components/expense-table.tsx
@@ -48,7 +48,8 @@ import {
   IconPhoto,
   IconX,
 } from "@tabler/icons-react";
-import { updateExpense, deleteExpense } from "@/lib/actions/expenses";
+import { updateExpense, deleteExpense, getUserTags } from "@/lib/actions/expenses";
+import { TagInput } from "@/components/tag-input";
 
 type AccountOption = {
   id: string;
@@ -88,8 +89,9 @@ type Expense = {
   accountId: string | null;
   date: Date;
   isVerified: boolean;
-  receiptUrl: string | null;  // Legacy single receipt
-  receiptUrls: string[];      // Multiple receipts array
+  receiptUrl: string | null;
+  receiptUrls: string[];
+  tags: string[];
 };
 
 type SortField = "date" | "amount" | "category";
@@ -121,6 +123,8 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
   const [editDate, setEditDate] = useState("");
   const [editAccountId, setEditAccountId] = useState("");
   const [editReceipt, setEditReceipt] = useState<File | null>(null);
+  const [editTags, setEditTags] = useState<string[]>([]);
+  const [editTagSuggestions, setEditTagSuggestions] = useState<string[]>([]);
   const [editLoading, setEditLoading] = useState(false);
   
   // Delete state
@@ -223,6 +227,8 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
     setEditDate(toLocalDateString(new Date(expense.date)));
     setEditAccountId(expense.accountId || "");
     setEditReceipt(null);
+    setEditTags(expense.tags || []);
+    getUserTags().then(setEditTagSuggestions);
   };
 
   const handleEdit = async () => {
@@ -238,6 +244,7 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
         date: new Date(editDate),
         paymentMethod: accountName || undefined,
         accountId: editAccountId || undefined,
+        tags: editTags,
       });
 
       // If there's a new receipt, upload it
@@ -410,6 +417,20 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                     {expense.paymentMethod}
                   </span>
                 )}
+                {expense.tags && expense.tags.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {expense.tags.slice(0, 3).map((tag) => (
+                      <Badge key={tag} variant="outline" className="text-[10px] px-1 py-0">
+                        {tag}
+                      </Badge>
+                    ))}
+                    {expense.tags.length > 3 && (
+                      <Badge variant="outline" className="text-[10px] px-1 py-0">
+                        +{expense.tags.length - 3} more
+                      </Badge>
+                    )}
+                  </div>
+                )}
               </div>
               <p className="text-sm font-bold whitespace-nowrap">
                 {formatCurrency(expense.amount)}
@@ -440,6 +461,7 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
               >
                 Category <SortIcon field="category" />
               </TableHead>
+              <TableHead>Tags</TableHead>
               <TableHead>Source</TableHead>
               <TableHead>Payment</TableHead>
               <TableHead
@@ -465,6 +487,24 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                 </TableCell>
                 <TableCell>
                   <Badge variant="secondary">{expense.category}</Badge>
+                </TableCell>
+                <TableCell>
+                  {expense.tags && expense.tags.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {expense.tags.slice(0, 3).map((tag) => (
+                        <Badge key={tag} variant="outline" className="text-[10px] px-1 py-0">
+                          {tag}
+                        </Badge>
+                      ))}
+                      {expense.tags.length > 3 && (
+                        <Badge variant="outline" className="text-[10px] px-1 py-0">
+                          +{expense.tags.length - 3}
+                        </Badge>
+                      )}
+                    </div>
+                  ) : (
+                    <span className="text-muted-foreground text-xs">-</span>
+                  )}
                 </TableCell>
                 <TableCell>
                   <span
@@ -539,6 +579,15 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                 id="edit-description"
                 value={editDescription}
                 onChange={(e) => setEditDescription(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Tags</Label>
+              <TagInput
+                value={editTags}
+                onChange={setEditTags}
+                suggestions={editTagSuggestions}
+                placeholder="Add keywords..."
               />
             </div>
             <div className="grid grid-cols-2 gap-4">

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -10,6 +10,7 @@ type PaginationProps = {
   search?: string;
   category?: string;
   excludeCategory?: string;
+  tag?: string;
 };
 
 export function Pagination({
@@ -18,6 +19,7 @@ export function Pagination({
   search,
   category,
   excludeCategory,
+  tag,
 }: PaginationProps) {
   const buildUrl = (page: number) => {
     const params = new URLSearchParams();
@@ -25,6 +27,7 @@ export function Pagination({
     if (search) params.set("search", search);
     if (category) params.set("category", category);
     if (excludeCategory) params.set("excludeCategory", excludeCategory);
+    if (tag) params.set("tag", tag);
     return `/expenses?${params.toString()}`;
   };
 

--- a/components/tag-input.tsx
+++ b/components/tag-input.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { IconX, IconTag } from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
+
+type TagInputProps = {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  suggestions: string[];
+  placeholder?: string;
+};
+
+export function TagInput({
+  value,
+  onChange,
+  suggestions,
+  placeholder = "Add tags...",
+}: TagInputProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filteredSuggestions = suggestions.filter(
+    (s) =>
+      s.toLowerCase().includes(inputValue.toLowerCase()) &&
+      !value.includes(s),
+  );
+
+  const addTag = useCallback(
+    (tag: string) => {
+      const trimmed = tag.trim().toLowerCase();
+      if (!trimmed || trimmed.length > 50) return;
+      if (!value.includes(trimmed)) {
+        onChange([...value, trimmed]);
+      }
+      setInputValue("");
+      setShowSuggestions(false);
+      setHighlightedIndex(-1);
+      inputRef.current?.focus();
+    },
+    [value, onChange],
+  );
+
+  const removeTag = useCallback(
+    (tag: string) => {
+      onChange(value.filter((t) => t !== tag));
+    },
+    [value, onChange],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && filteredSuggestions[highlightedIndex]) {
+        addTag(filteredSuggestions[highlightedIndex]);
+      } else if (inputValue.trim()) {
+        addTag(inputValue);
+      }
+    } else if (e.key === "Backspace" && !inputValue && value.length > 0) {
+      removeTag(value[value.length - 1]);
+    } else if (e.key === "ArrowDown" && filteredSuggestions.length > 0) {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < filteredSuggestions.length - 1 ? prev + 1 : 0,
+      );
+    } else if (e.key === "ArrowUp" && filteredSuggestions.length > 0) {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev > 0 ? prev - 1 : filteredSuggestions.length - 1,
+      );
+    } else if (e.key === "Escape") {
+      setShowSuggestions(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  const handleBlur = () => {
+    // Small delay to allow click on suggestion
+    setTimeout(() => {
+      setShowSuggestions(false);
+      setHighlightedIndex(-1);
+    }, 150);
+  };
+
+  return (
+    <div ref={containerRef} className="relative space-y-1.5">
+      <div className="flex min-h-8 flex-wrap items-center gap-1 rounded-md border border-input bg-transparent px-2.5 py-1 text-xs transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/50">
+        <IconTag className="h-3.5 w-3.5 text-muted-foreground" />
+        {value.map((tag) => (
+          <Badge
+            key={tag}
+            variant="secondary"
+            className="group/tag flex h-5 items-center gap-0.5 rounded-sm px-1.5 text-[11px] font-medium hover:bg-secondary/80"
+          >
+            {tag}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="ml-0.5 h-3 w-3 opacity-50 hover:opacity-100"
+              onClick={() => removeTag(tag)}
+              tabIndex={-1}
+            >
+              <IconX className="h-2.5 w-2.5" />
+            </Button>
+          </Badge>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            setShowSuggestions(true);
+            setHighlightedIndex(-1);
+          }}
+          onFocus={() => {
+            if (inputValue || suggestions.length > 0) {
+              setShowSuggestions(true);
+            }
+          }}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={value.length === 0 ? placeholder : ""}
+          className="min-w-[80px] flex-1 bg-transparent py-0.5 text-xs outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      {showSuggestions && filteredSuggestions.length > 0 && (
+        <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-40 overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
+          {filteredSuggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              type="button"
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs",
+                index === highlightedIndex
+                  ? "bg-accent text-accent-foreground"
+                  : "hover:bg-muted",
+              )}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                addTag(suggestion);
+              }}
+              onMouseEnter={() => setHighlightedIndex(index)}
+            >
+              <IconTag className="h-3 w-3 text-muted-foreground" />
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/actions/expenses.ts
+++ b/lib/actions/expenses.ts
@@ -30,6 +30,7 @@ const CreateExpenseSchema = z.object({
   paymentMethod: z.string().max(100).optional(),
   accountId: z.string().uuid().optional(),
   receiptUrl: z.string().max(500).optional(),
+  tags: z.array(z.string().max(50)).optional(),
 });
 
 const UpdateExpenseSchema = CreateExpenseSchema.partial();
@@ -43,6 +44,7 @@ const GetExpensesOptionsSchema = z.object({
   endDate: z.date().optional(),
   category: z.string().optional(),
   excludeCategory: z.string().optional(),
+  tag: z.string().optional(),
   search: z.string().max(200).optional(),
 }).optional();
 
@@ -51,6 +53,7 @@ const GetExpensesCountOptionsSchema = z.object({
   endDate: z.date().optional(),
   category: z.string().optional(),
   excludeCategory: z.string().optional(),
+  tag: z.string().optional(),
   search: z.string().max(200).optional(),
 }).optional();
 
@@ -86,6 +89,19 @@ async function recordBalanceHistory(
       date: date || new Date(),
     },
   });
+}
+
+export async function getUserTags(): Promise<string[]> {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Unauthorized");
+
+  const tags = await db.tag.findMany({
+    where: { userId },
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+
+  return tags.map((t) => t.name);
 }
 
 export async function createExpense(input: CreateExpenseInput) {
@@ -125,6 +141,22 @@ export async function createExpense(input: CreateExpenseInput) {
       }
     }
 
+    // Link tags
+    if (validated.tags && validated.tags.length > 0) {
+      for (const tagName of validated.tags) {
+        const trimmed = tagName.trim().toLowerCase();
+        if (!trimmed) continue;
+        const tag = await tx.tag.upsert({
+          where: { userId_name: { userId, name: trimmed } },
+          update: {},
+          create: { userId, name: trimmed },
+        });
+        await tx.expenseTag.create({
+          data: { expenseId: created.id, tagId: tag.id },
+        });
+      }
+    }
+
     return created;
   });
 
@@ -158,16 +190,28 @@ export async function getExpenses(options?: z.infer<typeof GetExpensesOptionsSch
     where.category = { not: validated.excludeCategory };
   }
 
+  if (validated?.tag) {
+    where.tags = {
+      some: {
+        tag: {
+          name: { contains: validated.tag, mode: "insensitive" },
+        },
+      },
+    };
+  }
+
   if (validated?.search) {
     where.OR = [
       { description: { contains: validated.search, mode: "insensitive" } },
       { merchant: { contains: validated.search, mode: "insensitive" } },
       { category: { contains: validated.search, mode: "insensitive" } },
+      { tags: { some: { tag: { name: { contains: validated.search, mode: "insensitive" } } } } },
     ];
   }
 
   const expenses = await db.expense.findMany({
     where,
+    include: { tags: { include: { tag: true } } },
     orderBy: [
       { createdAt: "desc" },
       { id: "desc" },
@@ -176,7 +220,10 @@ export async function getExpenses(options?: z.infer<typeof GetExpensesOptionsSch
     skip: validated?.offset,
   });
 
-  return expenses;
+  return expenses.map((e) => ({
+    ...e,
+    tags: e.tags?.map((et: { tag: { name: string } }) => et.tag.name) ?? [],
+  }));
 }
 
 export async function getExpensesCount(options?: z.infer<typeof GetExpensesCountOptionsSchema>) {
@@ -199,11 +246,22 @@ export async function getExpensesCount(options?: z.infer<typeof GetExpensesCount
     where.category = { not: validated.excludeCategory };
   }
 
+  if (validated?.tag) {
+    where.tags = {
+      some: {
+        tag: {
+          name: { contains: validated.tag, mode: "insensitive" },
+        },
+      },
+    };
+  }
+
   if (validated?.search) {
     where.OR = [
       { description: { contains: validated.search, mode: "insensitive" } },
       { merchant: { contains: validated.search, mode: "insensitive" } },
       { category: { contains: validated.search, mode: "insensitive" } },
+      { tags: { some: { tag: { name: { contains: validated.search, mode: "insensitive" } } } } },
     ];
   }
 
@@ -293,6 +351,23 @@ export async function updateExpense(
         receiptUrl: validated.receiptUrl,
       },
     });
+
+    // Handle tags if provided
+    if (validated.tags !== undefined) {
+      await tx.expenseTag.deleteMany({ where: { expenseId: validatedId } });
+      for (const tagName of validated.tags) {
+        const trimmed = tagName.trim().toLowerCase();
+        if (!trimmed) continue;
+        const tag = await tx.tag.upsert({
+          where: { userId_name: { userId, name: trimmed } },
+          update: {},
+          create: { userId, name: trimmed },
+        });
+        await tx.expenseTag.create({
+          data: { expenseId: validatedId, tagId: tag.id },
+        });
+      }
+    }
 
     return updated;
   });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,10 +44,32 @@ model Expense {
   receiptUrl    String?        // Legacy single receipt URL (deprecated)
   receiptUrls   String[]       @default([]) // URLs to receipts/invoices stored in Cloudflare R2
   createdAt     DateTime       @default(now())
+  tags          ExpenseTag[]
 
   @@index([userId])
   @@index([date])
   @@index([accountId])
+}
+
+model Tag {
+  id        String       @id @default(uuid())
+  userId    String
+  name      String
+  expenses  ExpenseTag[]
+  createdAt DateTime     @default(now())
+
+  @@unique([userId, name])
+  @@index([userId])
+}
+
+model ExpenseTag {
+  expenseId String
+  tagId     String
+  expense   Expense @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  tag       Tag     @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([expenseId, tagId])
+  @@index([tagId])
 }
 
 model LinkingCode {

--- a/tests/unit/actions/expenses.test.ts
+++ b/tests/unit/actions/expenses.test.ts
@@ -32,6 +32,14 @@ const mockDb = {
     balanceHistory: {
         create: vi.fn(),
     },
+    tag: {
+        findMany: vi.fn(),
+        upsert: vi.fn(),
+    },
+    expenseTag: {
+        create: vi.fn(),
+        deleteMany: vi.fn(),
+    },
     userSettings: {
         findUnique: vi.fn(),
         upsert: vi.fn(),
@@ -231,6 +239,7 @@ describe("Expense Actions", () => {
                     amount: 100,
                     category: "Food",
                     date: new Date(),
+                    tags: [],
                 },
                 {
                     id: UUIDS.expense2,
@@ -238,6 +247,7 @@ describe("Expense Actions", () => {
                     amount: 200,
                     category: "Travel",
                     date: new Date(),
+                    tags: [],
                 },
             ];
 
@@ -484,6 +494,259 @@ describe("Expense Actions", () => {
             const result = await getExpensesCount();
 
             expect(result).toEqual({ count: 42, totalAmount: 15000 });
+        });
+
+        it("should filter by tag", async () => {
+            mockDb.expense.aggregate.mockResolvedValue({
+                _count: { id: 3 },
+                _sum: { amount: 750 },
+            });
+
+            vi.resetModules();
+            const { getExpensesCount } = await import("@/lib/actions/expenses");
+
+            await getExpensesCount({ tag: "groceries" });
+
+            expect(mockDb.expense.aggregate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        tags: expect.objectContaining({
+                            some: expect.objectContaining({
+                                tag: expect.objectContaining({
+                                    name: expect.objectContaining({
+                                        contains: "groceries",
+                                    }),
+                                }),
+                            }),
+                        }),
+                    }),
+                })
+            );
+        });
+    });
+
+    describe("getUserTags", () => {
+        it("should return all tags for the current user", async () => {
+            mockDb.tag.findMany.mockResolvedValue([
+                { name: "groceries" },
+                { name: "office" },
+                { name: "subscription" },
+            ]);
+
+            vi.resetModules();
+            const { getUserTags } = await import("@/lib/actions/expenses");
+
+            const tags = await getUserTags();
+
+            expect(tags).toEqual(["groceries", "office", "subscription"]);
+            expect(mockDb.tag.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { userId: "test-user-id" },
+                    select: { name: true },
+                    orderBy: { name: "asc" },
+                })
+            );
+        });
+    });
+
+    describe("Tag CRUD", () => {
+        it("should create expense with tags", async () => {
+            const mockExpense = {
+                id: UUIDS.expense1,
+                userId: "test-user-id",
+                amount: 100,
+                category: "Food",
+                merchant: "Restaurant",
+            };
+
+            mockDb.expense.create.mockResolvedValue(mockExpense);
+            mockDb.tag.upsert
+                .mockResolvedValueOnce({ id: "tag-1", name: "lunch" })
+                .mockResolvedValueOnce({ id: "tag-2", name: "office" });
+            mockDb.expenseTag.create.mockResolvedValue({});
+
+            vi.resetModules();
+            const { createExpense } = await import("@/lib/actions/expenses");
+
+            await createExpense({
+                amount: 100,
+                category: "Food",
+                merchant: "Restaurant",
+                tags: ["lunch", "office"],
+            });
+
+            expect(mockDb.tag.upsert).toHaveBeenCalledTimes(2);
+            expect(mockDb.tag.upsert).toHaveBeenNthCalledWith(1, {
+                where: { userId_name: { userId: "test-user-id", name: "lunch" } },
+                update: {},
+                create: { userId: "test-user-id", name: "lunch" },
+            });
+            expect(mockDb.tag.upsert).toHaveBeenNthCalledWith(2, {
+                where: { userId_name: { userId: "test-user-id", name: "office" } },
+                update: {},
+                create: { userId: "test-user-id", name: "office" },
+            });
+            expect(mockDb.expenseTag.create).toHaveBeenCalledTimes(2);
+        });
+
+        it("should skip empty tags", async () => {
+            const mockExpense = {
+                id: UUIDS.expense1,
+                userId: "test-user-id",
+                amount: 100,
+                category: "Food",
+            };
+
+            mockDb.expense.create.mockResolvedValue(mockExpense);
+            mockDb.tag.upsert.mockResolvedValue({ id: "tag-1", name: "lunch" });
+            mockDb.expenseTag.create.mockResolvedValue({});
+
+            vi.resetModules();
+            const { createExpense } = await import("@/lib/actions/expenses");
+
+            await createExpense({
+                amount: 100,
+                category: "Food",
+                tags: ["  lunch  ", "  ", ""],
+            });
+
+            // Only "lunch" should be created (trimmed, non-empty)
+            expect(mockDb.tag.upsert).toHaveBeenCalledTimes(1);
+            expect(mockDb.tag.upsert).toHaveBeenCalledWith({
+                where: { userId_name: { userId: "test-user-id", name: "lunch" } },
+                update: {},
+                create: { userId: "test-user-id", name: "lunch" },
+            });
+        });
+
+        it("should update expense tags - replace existing with new", async () => {
+            const existingExpense = {
+                id: UUIDS.expense1,
+                userId: "test-user-id",
+                amount: 100,
+                category: "Food",
+                accountId: null,
+            };
+
+            mockDb.expense.findFirst.mockResolvedValue(existingExpense);
+            mockDb.expense.update.mockResolvedValue(existingExpense);
+            mockDb.expenseTag.deleteMany.mockResolvedValue({ count: 2 });
+            mockDb.tag.upsert
+                .mockResolvedValueOnce({ id: "tag-1", name: "dinner" })
+                .mockResolvedValueOnce({ id: "tag-2", name: "party" });
+            mockDb.expenseTag.create.mockResolvedValue({});
+
+            vi.resetModules();
+            const { updateExpense } = await import("@/lib/actions/expenses");
+
+            await updateExpense(UUIDS.expense1, { tags: ["dinner", "party"] });
+
+            expect(mockDb.expenseTag.deleteMany).toHaveBeenCalledWith({
+                where: { expenseId: UUIDS.expense1 },
+            });
+            expect(mockDb.tag.upsert).toHaveBeenCalledTimes(2);
+            expect(mockDb.expenseTag.create).toHaveBeenCalledTimes(2);
+        });
+
+        it("should filter expenses by tag", async () => {
+            mockDb.expense.findMany.mockResolvedValue([]);
+
+            vi.resetModules();
+            const { getExpenses } = await import("@/lib/actions/expenses");
+
+            await getExpenses({ tag: "groceries" });
+
+            expect(mockDb.expense.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        tags: expect.objectContaining({
+                            some: expect.objectContaining({
+                                tag: expect.objectContaining({
+                                    name: expect.objectContaining({
+                                        contains: "groceries",
+                                    }),
+                                }),
+                            }),
+                        }),
+                    }),
+                })
+            );
+        });
+
+        it("should search by tag text in main search", async () => {
+            mockDb.expense.findMany.mockResolvedValue([]);
+
+            vi.resetModules();
+            const { getExpenses } = await import("@/lib/actions/expenses");
+
+            await getExpenses({ search: "groceries" });
+
+            expect(mockDb.expense.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        OR: expect.arrayContaining([
+                            expect.objectContaining({
+                                tags: expect.objectContaining({
+                                    some: expect.objectContaining({
+                                        tag: expect.objectContaining({
+                                            name: expect.objectContaining({
+                                                contains: "groceries",
+                                            }),
+                                        }),
+                                    }),
+                                }),
+                            }),
+                        ]),
+                    }),
+                })
+            );
+        });
+
+        it("should leave tags untouched when tags is undefined in update", async () => {
+            const existingExpense = {
+                id: UUIDS.expense1,
+                userId: "test-user-id",
+                amount: 100,
+                category: "Food",
+                accountId: null,
+            };
+
+            mockDb.expense.findFirst.mockResolvedValue(existingExpense);
+            mockDb.expense.update.mockResolvedValue(existingExpense);
+
+            vi.resetModules();
+            const { updateExpense } = await import("@/lib/actions/expenses");
+
+            await updateExpense(UUIDS.expense1, { amount: 200 });
+
+            // Tags not provided - should not touch expenseTag at all
+            expect(mockDb.expenseTag.deleteMany).not.toHaveBeenCalled();
+            expect(mockDb.expenseTag.create).not.toHaveBeenCalled();
+        });
+
+        it("should clear all tags when empty array provided", async () => {
+            const existingExpense = {
+                id: UUIDS.expense1,
+                userId: "test-user-id",
+                amount: 100,
+                category: "Food",
+                accountId: null,
+            };
+
+            mockDb.expense.findFirst.mockResolvedValue(existingExpense);
+            mockDb.expense.update.mockResolvedValue(existingExpense);
+            mockDb.expenseTag.deleteMany.mockResolvedValue({ count: 2 });
+
+            vi.resetModules();
+            const { updateExpense } = await import("@/lib/actions/expenses");
+
+            await updateExpense(UUIDS.expense1, { tags: [] });
+
+            expect(mockDb.expenseTag.deleteMany).toHaveBeenCalledWith({
+                where: { expenseId: UUIDS.expense1 },
+            });
+            // No tags to create
+            expect(mockDb.expenseTag.create).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Closes #50

## Summary
Add multi-keyword tagging for expenses. Tags coexist with category filtering. Each expense can have multiple tags, shown as badges in the table view.

## Changes

### Database
- New `Tag` and `ExpenseTag` models with many-to-many relation on `Expense`
- Unique per-user tag names, case-insensitive via trimming

### Server Actions
- `tags` field added to `CreateExpenseSchema` / `UpdateExpenseSchema`
- New `getUserTags()` action for typeahead suggestions
- Tag filtering via `tag` query param in `getExpenses` / `getExpensesCount`
- Main search now also matches tag names
- Tag upsert + junction record creation inside transactions

### Frontend
- **TagInput**: New reusable component with chips, typeahead suggestions, keyboard nav, deduplication
- **Add Dialog**: Tag input field with auto-fetched existing tag suggestions
- **Edit Dialog**: Pre-populated tag input, tags passed to `updateExpense`
- **Table**: Tags column between Category and Source (desktop), tag badges on mobile cards, max 3 visible with "+N more"
- **Filters Bar**: Tag filter input alongside search and category, preserved in pagination
- **Pagination**: Preserves `tag` query param

### Tests
- 9 new unit tests: tag CRUD, filtering, search matching, empty/clear edge cases
- All 87 tests pass (26 expense tests, 61 others)

## Verification
- `pnpm build` ✅
- `pnpm lint` ✅ (only pre-existing warning)
- `pnpm test:run` ✅ (87/87 passing)