### PR TITLE
feat: multi-tag filtering and date range presets on expenses page

### DIFF
--- a/app/(dashboard)/expenses/page.tsx
+++ b/app/(dashboard)/expenses/page.tsx
@@ -4,22 +4,29 @@ import { ExpenseTable } from "@/components/expense-table";
 import { ExpenseFilters } from "@/components/expense-filters";
 import { Pagination } from "@/components/pagination";
 import { getExpenses, getExpensesCount, getUserTags } from "@/lib/actions/expenses";
+import type { DateRangePreset } from "@/lib/actions/expenses";
 import { getUserSettings } from "@/lib/actions/settings";
 import { getAccounts } from "@/lib/actions/accounts";
 
 const ITEMS_PER_PAGE = 10;
 
+const DATE_RANGE_PRESETS = ["this_month", "last_month", "last_3_months", "last_6_months", "this_year"] as const;
+
 export default async function ExpensesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; search?: string; category?: string; excludeCategory?: string; tag?: string }>;
+  searchParams: Promise<{ page?: string; search?: string; category?: string; excludeCategory?: string; tags?: string | string[]; dateRange?: string }>;
 }) {
   const params = await searchParams;
   const page = parseInt(params.page || "1", 10);
   const search = params.search || "";
   const category = params.category || "";
   const excludeCategory = params.excludeCategory || "";
-  const tag = params.tag || "";
+  const rawTags = params.tags;
+  const tags = rawTags ? (Array.isArray(rawTags) ? rawTags : [rawTags]) : [];
+  const dateRange = DATE_RANGE_PRESETS.includes(params.dateRange as DateRangePreset)
+    ? (params.dateRange as DateRangePreset)
+    : undefined;
   const offset = (page - 1) * ITEMS_PER_PAGE;
 
   const [expenses, { count: totalCount, totalAmount }, settings, accounts, allTags] = await Promise.all([
@@ -29,13 +36,15 @@ export default async function ExpensesPage({
       search: search || undefined,
       category: category || undefined,
       excludeCategory: excludeCategory || undefined,
-      tag: tag || undefined,
+      tags: tags.length > 0 ? tags : undefined,
+      dateRange,
     }),
     getExpensesCount({
       search: search || undefined,
       category: category || undefined,
       excludeCategory: excludeCategory || undefined,
-      tag: tag || undefined,
+      tags: tags.length > 0 ? tags : undefined,
+      dateRange,
     }),
     getUserSettings(),
     getAccounts(),
@@ -51,6 +60,8 @@ export default async function ExpensesPage({
       minimumFractionDigits: 2,
     }).format(amount);
   };
+
+  const hasFilters = search || category || excludeCategory || tags.length > 0 || dateRange;
 
   return (
     <div className="p-4 md:p-6">
@@ -70,7 +81,8 @@ export default async function ExpensesPage({
         currentSearch={search}
         currentCategory={category}
         currentExcludeCategory={excludeCategory}
-        currentTag={tag}
+        currentTags={tags}
+        currentDateRange={dateRange}
         allTags={allTags}
       />
 
@@ -78,7 +90,7 @@ export default async function ExpensesPage({
       <Card className="border">
         <CardHeader>
           <CardTitle className="text-sm font-medium">
-            {search || category || excludeCategory || tag
+            {hasFilters
               ? `Filtered Expenses (${totalCount}) - ${formatCurrency(totalAmount)}`
               : `All Expenses (${totalCount}) - ${formatCurrency(totalAmount)}`}
           </CardTitle>
@@ -94,14 +106,15 @@ export default async function ExpensesPage({
                   search={search}
                   category={category}
                   excludeCategory={excludeCategory}
-                  tag={tag}
+                  tags={tags}
+                  dateRange={dateRange}
                 />
               )}
             </>
           ) : (
             <div className="flex h-48 items-center justify-center">
               <p className="text-sm text-muted-foreground">
-                {search || category || excludeCategory || tag
+                {hasFilters
                   ? "No expenses match your filters."
                   : "No expenses yet. Add your first expense to get started."}
               </p>

--- a/components/expense-filters.tsx
+++ b/components/expense-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, useRef, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -12,8 +12,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { IconSearch, IconX, IconTag } from "@tabler/icons-react";
+import { IconSearch, IconX, IconCalendar } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import type { DateRangePreset } from "@/lib/actions/expenses";
 
 const categories = [
   "All",
@@ -29,11 +30,20 @@ const categories = [
   "General",
 ];
 
+const DATE_RANGE_OPTIONS: { value: DateRangePreset; label: string }[] = [
+  { value: "this_month", label: "This Month" },
+  { value: "last_month", label: "Last Month" },
+  { value: "last_3_months", label: "Last 3 Months" },
+  { value: "last_6_months", label: "Last 6 Months" },
+  { value: "this_year", label: "This Year" },
+];
+
 type ExpenseFiltersProps = {
   currentSearch: string;
   currentCategory: string;
   currentExcludeCategory?: string;
-  currentTag?: string;
+  currentTags?: string[];
+  currentDateRange?: DateRangePreset;
   allTags?: string[];
 };
 
@@ -41,242 +51,156 @@ export function ExpenseFilters({
   currentSearch,
   currentCategory,
   currentExcludeCategory,
-  currentTag = "",
+  currentTags = [],
+  currentDateRange,
   allTags = [],
 }: ExpenseFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState(currentSearch);
-  const [tag, setTag] = useState(currentTag);
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const tagInputRef = useRef<HTMLInputElement>(null);
 
-  const filteredSuggestions = allTags.filter(
-    (t) =>
-      t.toLowerCase().includes(tag.toLowerCase()) &&
-      t !== tag,
-  );
+  const updateFilters = (updates: {
+    search?: string;
+    category?: string;
+    tags?: string[];
+    dateRange?: DateRangePreset | "";
+  }) => {
+    const params = new URLSearchParams();
 
-  const updateFilters = (
-    newSearch: string,
-    newCategory: string,
-    newTag: string,
-  ) => {
-    const params = new URLSearchParams(searchParams.toString());
+    const newSearch = updates.search !== undefined ? updates.search : search;
+    const newCategory = updates.category !== undefined ? updates.category : currentCategory;
+    const newTags = updates.tags !== undefined ? updates.tags : currentTags;
+    const newDateRange = updates.dateRange !== undefined ? updates.dateRange : currentDateRange;
 
-    if (newSearch) {
-      params.set("search", newSearch);
-    } else {
-      params.delete("search");
-    }
-
+    if (newSearch) params.set("search", newSearch);
     if (newCategory && newCategory !== "All") {
       params.set("category", newCategory);
-      params.delete("excludeCategory");
-    } else {
-      params.delete("category");
-      if (currentExcludeCategory) {
-        params.set("excludeCategory", currentExcludeCategory);
-      }
+    } else if (currentExcludeCategory && !newCategory) {
+      params.set("excludeCategory", currentExcludeCategory);
     }
-
-    if (newTag) {
-      params.set("tag", newTag);
-    } else {
-      params.delete("tag");
-    }
-
-    params.delete("page");
+    for (const t of newTags) params.append("tags", t);
+    if (newDateRange) params.set("dateRange", newDateRange);
 
     startTransition(() => {
       router.push(`/expenses?${params.toString()}`);
     });
   };
 
-  const selectTag = (selectedTag: string) => {
-    setTag(selectedTag);
-    setShowSuggestions(false);
-    setHighlightedIndex(-1);
-    updateFilters(search, currentCategory, selectedTag);
+  const toggleTag = (tag: string) => {
+    const next = currentTags.includes(tag)
+      ? currentTags.filter((t) => t !== tag)
+      : [...currentTags, tag];
+    updateFilters({ tags: next });
   };
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    updateFilters(search, currentCategory, tag);
-  };
-
-  const handleCategoryChange = (value: string) => {
-    updateFilters(search, value, tag);
-  };
-
-  const handleTagChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTag(e.target.value);
-    setShowSuggestions(true);
-    setHighlightedIndex(-1);
-  };
-
-  const handleTagKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      if (highlightedIndex >= 0 && filteredSuggestions[highlightedIndex]) {
-        selectTag(filteredSuggestions[highlightedIndex]);
-      } else {
-        setShowSuggestions(false);
-        updateFilters(search, currentCategory, tag);
-      }
-    } else if (e.key === "ArrowDown" && filteredSuggestions.length > 0) {
-      e.preventDefault();
-      setHighlightedIndex((prev) =>
-        prev < filteredSuggestions.length - 1 ? prev + 1 : 0,
-      );
-    } else if (e.key === "ArrowUp" && filteredSuggestions.length > 0) {
-      e.preventDefault();
-      setHighlightedIndex((prev) =>
-        prev > 0 ? prev - 1 : filteredSuggestions.length - 1,
-      );
-    } else if (e.key === "Escape") {
-      setShowSuggestions(false);
-      setHighlightedIndex(-1);
-    }
+    updateFilters({ search });
   };
 
   const clearFilters = () => {
     setSearch("");
-    setTag("");
-    startTransition(() => {
-      router.push("/expenses");
-    });
+    startTransition(() => router.push("/expenses"));
   };
 
   const hasFilters =
-    currentSearch || currentCategory || currentExcludeCategory || currentTag;
+    currentSearch || currentCategory || currentExcludeCategory || currentTags.length > 0 || currentDateRange;
+
+  // Preserve existing searchParams for category change (keep other filters)
+  const handleCategoryChange = (value: string) => {
+    updateFilters({ category: value });
+  };
+
+  const handleDateRangeChange = (value: string) => {
+    updateFilters({ dateRange: value === "all" ? "" : (value as DateRangePreset) });
+  };
 
   return (
-    <div className="mb-6 space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+    <div className="mb-6 space-y-3">
+      {/* Row 1: search + category + date range + clear */}
+      <div className="flex flex-wrap items-center gap-3">
         <form onSubmit={handleSearch} className="flex items-center gap-2">
-          <div className="relative flex-1 sm:flex-initial">
+          <div className="relative">
             <IconSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="text"
               placeholder="Search expenses..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full pl-9 sm:w-64"
+              className="w-56 pl-9"
             />
           </div>
-          <Button type="submit" variant="secondary" disabled={isPending}>
+          <Button type="submit" variant="secondary" size="sm" disabled={isPending}>
             Search
           </Button>
         </form>
 
-        <div className="flex items-center gap-3">
-          <Select
-            value={currentCategory || "All"}
-            onValueChange={handleCategoryChange}
-          >
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Category" />
-            </SelectTrigger>
-            <SelectContent>
-              {categories.map((cat) => (
-                <SelectItem key={cat} value={cat}>
-                  {cat}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <Select value={currentCategory || "All"} onValueChange={handleCategoryChange}>
+          <SelectTrigger className="w-36">
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            {categories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-          <div className="relative">
-            <div className="relative">
-              <IconTag className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                ref={tagInputRef}
-                type="text"
-                placeholder="Filter by tag..."
-                value={tag}
-                onChange={handleTagChange}
-                onKeyDown={handleTagKeyDown}
-                onFocus={() => {
-                  if (tag || allTags.length > 0) setShowSuggestions(true);
-                }}
-                onBlur={() => {
-                  setTimeout(() => {
-                    setShowSuggestions(false);
-                    setHighlightedIndex(-1);
-                  }, 150);
-                }}
-                className="w-full pl-7 sm:w-36"
-              />
-            </div>
-            {showSuggestions && filteredSuggestions.length > 0 && (
-              <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-32 overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
-                {filteredSuggestions.map((suggestion, index) => (
-                  <button
-                    key={suggestion}
-                    type="button"
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs",
-                      index === highlightedIndex
-                        ? "bg-accent text-accent-foreground"
-                        : "hover:bg-muted",
-                    )}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      selectTag(suggestion);
-                    }}
-                    onMouseEnter={() => setHighlightedIndex(index)}
-                  >
-                    <IconTag className="h-3 w-3 text-muted-foreground" />
-                    {suggestion}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+        <Select value={currentDateRange || "all"} onValueChange={handleDateRangeChange}>
+          <SelectTrigger className="w-40">
+            <IconCalendar className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
+            <SelectValue placeholder="Date range" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All time</SelectItem>
+            {DATE_RANGE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-          {hasFilters && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={clearFilters}
-              disabled={isPending}
-            >
-              <IconX className="mr-1 h-4 w-4" />
-              Clear
-            </Button>
-          )}
-        </div>
+        {hasFilters && (
+          <Button variant="ghost" size="sm" onClick={clearFilters} disabled={isPending}>
+            <IconX className="mr-1 h-4 w-4" />
+            Clear
+          </Button>
+        )}
       </div>
 
+      {/* Row 2: tag pills (multi-select) */}
       {allTags.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="text-xs text-muted-foreground">Tags:</span>
-          {allTags.map((t) => (
-            <Badge
-              key={t}
-              variant={t === currentTag ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer text-[11px] px-2 py-0.5 transition-colors",
-                t === currentTag
-                  ? "hover:bg-primary/90"
-                  : "hover:bg-secondary/80",
-              )}
-              onClick={() => {
-                if (t === currentTag) {
-                  setTag("");
-                  updateFilters(search, currentCategory, "");
-                } else {
-                  setTag(t);
-                  updateFilters(search, currentCategory, t);
-                }
-              }}
+          {allTags.map((t) => {
+            const active = currentTags.includes(t);
+            return (
+              <Badge
+                key={t}
+                variant={active ? "default" : "secondary"}
+                className={cn(
+                  "cursor-pointer text-[11px] px-2 py-0.5 transition-colors select-none",
+                  active ? "hover:bg-primary/90" : "hover:bg-secondary/80",
+                )}
+                onClick={() => toggleTag(t)}
+              >
+                {t}
+              </Badge>
+            );
+          })}
+          {currentTags.length > 0 && (
+            <button
+              type="button"
+              className="text-[11px] text-muted-foreground hover:text-foreground underline"
+              onClick={() => updateFilters({ tags: [] })}
             >
-              {t}
-            </Badge>
-          ))}
+              clear tags
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/components/expense-filters.tsx
+++ b/components/expense-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -56,7 +56,6 @@ export function ExpenseFilters({
   allTags = [],
 }: ExpenseFiltersProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const [search, setSearch] = useState(currentSearch);
 

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import type { DateRangePreset } from "@/lib/actions/expenses";
 
 type PaginationProps = {
   currentPage: number;
@@ -10,7 +11,8 @@ type PaginationProps = {
   search?: string;
   category?: string;
   excludeCategory?: string;
-  tag?: string;
+  tags?: string[];
+  dateRange?: DateRangePreset;
 };
 
 export function Pagination({
@@ -19,7 +21,8 @@ export function Pagination({
   search,
   category,
   excludeCategory,
-  tag,
+  tags = [],
+  dateRange,
 }: PaginationProps) {
   const buildUrl = (page: number) => {
     const params = new URLSearchParams();
@@ -27,7 +30,8 @@ export function Pagination({
     if (search) params.set("search", search);
     if (category) params.set("category", category);
     if (excludeCategory) params.set("excludeCategory", excludeCategory);
-    if (tag) params.set("tag", tag);
+    for (const t of tags) params.append("tags", t);
+    if (dateRange) params.set("dateRange", dateRange);
     return `/expenses?${params.toString()}`;
   };
 

--- a/lib/actions/expenses.ts
+++ b/lib/actions/expenses.ts
@@ -37,23 +37,46 @@ const UpdateExpenseSchema = CreateExpenseSchema.partial();
 
 export type CreateExpenseInput = z.infer<typeof CreateExpenseSchema>;
 
+const DATE_RANGE_PRESETS = ["this_month", "last_month", "last_3_months", "last_6_months", "this_year"] as const;
+export type DateRangePreset = (typeof DATE_RANGE_PRESETS)[number];
+
+function getDateRangeFromPreset(preset: DateRangePreset, timezone: string): { startDate: Date; endDate: Date } {
+  const now = getNowInTimezone(timezone);
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  switch (preset) {
+    case "this_month":
+      return { startDate: new Date(y, m, 1), endDate: new Date(y, m + 1, 0, 23, 59, 59) };
+    case "last_month":
+      return { startDate: new Date(y, m - 1, 1), endDate: new Date(y, m, 0, 23, 59, 59) };
+    case "last_3_months":
+      return { startDate: new Date(y, m - 2, 1), endDate: new Date(y, m + 1, 0, 23, 59, 59) };
+    case "last_6_months":
+      return { startDate: new Date(y, m - 5, 1), endDate: new Date(y, m + 1, 0, 23, 59, 59) };
+    case "this_year":
+      return { startDate: new Date(y, 0, 1), endDate: new Date(y, 11, 31, 23, 59, 59) };
+  }
+}
+
 const GetExpensesOptionsSchema = z.object({
   limit: z.number().int().positive().optional(),
   offset: z.number().int().nonnegative().optional(),
   startDate: z.date().optional(),
   endDate: z.date().optional(),
+  dateRange: z.enum(DATE_RANGE_PRESETS).optional(),
   category: z.string().optional(),
   excludeCategory: z.string().optional(),
-  tag: z.string().optional(),
+  tags: z.array(z.string()).optional(),
   search: z.string().max(200).optional(),
 }).optional();
 
 const GetExpensesCountOptionsSchema = z.object({
   startDate: z.date().optional(),
   endDate: z.date().optional(),
+  dateRange: z.enum(DATE_RANGE_PRESETS).optional(),
   category: z.string().optional(),
   excludeCategory: z.string().optional(),
-  tag: z.string().optional(),
+  tags: z.array(z.string()).optional(),
   search: z.string().max(200).optional(),
 }).optional();
 
@@ -178,10 +201,19 @@ export async function getExpenses(options?: z.infer<typeof GetExpensesOptionsSch
 
   const where: Record<string, unknown> = { userId };
 
-  if (validated?.startDate || validated?.endDate) {
+  // Resolve date range
+  let startDate = validated?.startDate;
+  let endDate = validated?.endDate;
+  if (validated?.dateRange) {
+    const settings = await getUserSettings();
+    const range = getDateRangeFromPreset(validated.dateRange, settings.timezone || "UTC");
+    startDate = range.startDate;
+    endDate = range.endDate;
+  }
+  if (startDate || endDate) {
     where.date = {};
-    if (validated.startDate) (where.date as Record<string, Date>).gte = validated.startDate;
-    if (validated.endDate) (where.date as Record<string, Date>).lte = validated.endDate;
+    if (startDate) (where.date as Record<string, Date>).gte = startDate;
+    if (endDate) (where.date as Record<string, Date>).lte = endDate;
   }
 
   if (validated?.category) {
@@ -190,11 +222,11 @@ export async function getExpenses(options?: z.infer<typeof GetExpensesOptionsSch
     where.category = { not: validated.excludeCategory };
   }
 
-  if (validated?.tag) {
+  if (validated?.tags && validated.tags.length > 0) {
     where.tags = {
       some: {
         tag: {
-          name: { contains: validated.tag, mode: "insensitive" },
+          name: { in: validated.tags, mode: "insensitive" },
         },
       },
     };
@@ -234,10 +266,19 @@ export async function getExpensesCount(options?: z.infer<typeof GetExpensesCount
 
   const where: Record<string, unknown> = { userId };
 
-  if (validated?.startDate || validated?.endDate) {
+  // Resolve date range
+  let startDate = validated?.startDate;
+  let endDate = validated?.endDate;
+  if (validated?.dateRange) {
+    const settings = await getUserSettings();
+    const range = getDateRangeFromPreset(validated.dateRange, settings.timezone || "UTC");
+    startDate = range.startDate;
+    endDate = range.endDate;
+  }
+  if (startDate || endDate) {
     where.date = {};
-    if (validated.startDate) (where.date as Record<string, Date>).gte = validated.startDate;
-    if (validated.endDate) (where.date as Record<string, Date>).lte = validated.endDate;
+    if (startDate) (where.date as Record<string, Date>).gte = startDate;
+    if (endDate) (where.date as Record<string, Date>).lte = endDate;
   }
 
   if (validated?.category) {
@@ -246,11 +287,11 @@ export async function getExpensesCount(options?: z.infer<typeof GetExpensesCount
     where.category = { not: validated.excludeCategory };
   }
 
-  if (validated?.tag) {
+  if (validated?.tags && validated.tags.length > 0) {
     where.tags = {
       some: {
         tag: {
-          name: { contains: validated.tag, mode: "insensitive" },
+          name: { in: validated.tags, mode: "insensitive" },
         },
       },
     };

--- a/tests/unit/actions/expenses.test.ts
+++ b/tests/unit/actions/expenses.test.ts
@@ -505,7 +505,7 @@ describe("Expense Actions", () => {
             vi.resetModules();
             const { getExpensesCount } = await import("@/lib/actions/expenses");
 
-            await getExpensesCount({ tag: "groceries" });
+            await getExpensesCount({ tags: ["groceries"] });
 
             expect(mockDb.expense.aggregate).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -514,7 +514,7 @@ describe("Expense Actions", () => {
                             some: expect.objectContaining({
                                 tag: expect.objectContaining({
                                     name: expect.objectContaining({
-                                        contains: "groceries",
+                                        in: ["groceries"],
                                     }),
                                 }),
                             }),
@@ -654,7 +654,7 @@ describe("Expense Actions", () => {
             vi.resetModules();
             const { getExpenses } = await import("@/lib/actions/expenses");
 
-            await getExpenses({ tag: "groceries" });
+            await getExpenses({ tags: ["groceries"] });
 
             expect(mockDb.expense.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -663,7 +663,7 @@ describe("Expense Actions", () => {
                             some: expect.objectContaining({
                                 tag: expect.objectContaining({
                                     name: expect.objectContaining({
-                                        contains: "groceries",
+                                        in: ["groceries"],
                                     }),
                                 }),
                             }),


### PR DESCRIPTION
## Summary

- **Multi-tag filtering**: Tag pills in the filter bar are now multi-select. Click to toggle individual tags; active tags are highlighted. URL uses repeated `tags=` params.
- **Date range presets**: New dropdown with options — This Month, Last Month, Last 3 Months, Last 6 Months, This Year.
- Pagination preserves both filters across pages.

## Changes
- `lib/actions/expenses.ts` — `tag` → `tags: string[]` with Prisma `in` filter; added `dateRange` preset resolved in user timezone
- `app/(dashboard)/expenses/page.tsx` — updated search params parsing
- `components/expense-filters.tsx` — rewritten with multi-tag pills + date range select
- `components/pagination.tsx` — updated to carry `tags[]` and `dateRange`

## Tested
- TypeScript compiles with zero errors (`tsc --noEmit`)