### PR TITLE
feat(loans): link loans to accounts with transactional expense + balance tracking

### DIFF
--- a/app/(dashboard)/loans/page.tsx
+++ b/app/(dashboard)/loans/page.tsx
@@ -1,15 +1,17 @@
 import { getLoans, getLoanStats } from "@/lib/actions/loans";
 import { getUserSettings } from "@/lib/actions/settings";
+import { getAccounts } from "@/lib/actions/accounts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { IconCash, IconCashOff, IconUsers, IconCheck } from "@tabler/icons-react";
 import { LoanList } from "@/components/loan-list";
 import { AddLoanDialog } from "@/components/add-loan-dialog";
 
 export default async function LoansPage() {
-  const [loans, stats, settings] = await Promise.all([
+  const [loans, stats, settings, accounts] = await Promise.all([
     getLoans(),
     getLoanStats(),
     getUserSettings(),
+    getAccounts(),
   ]);
 
   const formatCurrency = (amount: number) => {
@@ -29,7 +31,15 @@ export default async function LoansPage() {
             Track money you&apos;ve lent to others
           </p>
         </div>
-        <AddLoanDialog currency={settings.currency} />
+        <AddLoanDialog
+          currency={settings.currency}
+          accounts={accounts.map((a) => ({
+            id: a.id,
+            name: a.name,
+            type: a.type,
+            currentBalance: a.currentBalance,
+          }))}
+        />
       </div>
 
       {/* Stats Cards */}

--- a/components/add-expense-dialog.tsx
+++ b/components/add-expense-dialog.tsx
@@ -42,6 +42,7 @@ const categories = [
   "Education",
   "Investments",
   "Subscription",
+  "Lent Money",
   "General",
 ] as const;
 

--- a/components/add-loan-dialog.tsx
+++ b/components/add-loan-dialog.tsx
@@ -16,14 +16,29 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { IconPlus, IconUpload, IconX } from "@tabler/icons-react";
 import { createLoan, addLoanReceipt } from "@/lib/actions/loans";
 
-type AddLoanDialogProps = {
-  currency: string;
+type AccountOption = {
+  id: string;
+  name: string;
+  type: string;
+  currentBalance: number;
 };
 
-export function AddLoanDialog({ currency }: AddLoanDialogProps) {
+type AddLoanDialogProps = {
+  currency: string;
+  accounts?: AccountOption[];
+};
+
+export function AddLoanDialog({ currency, accounts = [] }: AddLoanDialogProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -34,6 +49,7 @@ export function AddLoanDialog({ currency }: AddLoanDialogProps) {
   const [lendDate, setLendDate] = useState(toLocalDateString());
   const [dueDate, setDueDate] = useState("");
   const [description, setDescription] = useState("");
+  const [accountId, setAccountId] = useState<string>("none");
   const [receiptFiles, setReceiptFiles] = useState<File[]>([]);
   const [uploading, setUploading] = useState(false);
 
@@ -44,6 +60,7 @@ export function AddLoanDialog({ currency }: AddLoanDialogProps) {
     setLendDate(toLocalDateString());
     setDueDate("");
     setDescription("");
+    setAccountId("none");
     setReceiptFiles([]);
   };
 
@@ -69,9 +86,9 @@ export function AddLoanDialog({ currency }: AddLoanDialogProps) {
         lendDate: new Date(lendDate),
         dueDate: dueDate ? new Date(dueDate) : undefined,
         description: description || undefined,
+        accountId: accountId !== "none" ? accountId : undefined,
       });
 
-      // Upload receipts if any
       if (receiptFiles.length > 0 && loan) {
         setUploading(true);
         for (const file of receiptFiles) {
@@ -104,6 +121,15 @@ export function AddLoanDialog({ currency }: AddLoanDialogProps) {
   };
 
   const currencySymbol = currency === "INR" ? "₹" : currency === "USD" ? "$" : currency === "EUR" ? "€" : "£";
+
+  const formatBalance = (balance: number) => {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(balance);
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -177,6 +203,28 @@ export function AddLoanDialog({ currency }: AddLoanDialogProps) {
                 onChange={(e) => setDueDate(e.target.value)}
               />
             </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="accountId">From Account (optional)</Label>
+            <Select value={accountId} onValueChange={setAccountId}>
+              <SelectTrigger id="accountId">
+                <SelectValue placeholder="Select account" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None (no balance tracking)</SelectItem>
+                {accounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {account.name} ({formatBalance(account.currentBalance)})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {accountId !== "none" && (
+              <p className="text-xs text-muted-foreground">
+                Balance will be deducted and an expense will be recorded.
+              </p>
+            )}
           </div>
 
           <div className="grid gap-2">

--- a/components/expense-filters.tsx
+++ b/components/expense-filters.tsx
@@ -27,6 +27,7 @@ const categories = [
   "Education",
   "Investments",
   "Subscription",
+  "Lent Money",
   "General",
 ];
 

--- a/components/expense-table.tsx
+++ b/components/expense-table.tsx
@@ -67,6 +67,7 @@ const categories = [
   "Education",
   "Investments",
   "Subscription",
+  "Lent Money",
   "General",
 ] as const;
 
@@ -87,11 +88,17 @@ type Expense = {
   source: string;
   paymentMethod: string | null;
   accountId: string | null;
+  loanId: string | null;
+  repaymentId: string | null;
   date: Date;
   isVerified: boolean;
   receiptUrl: string | null;
   receiptUrls: string[];
   tags: string[];
+  loan?: {
+    id: string;
+    borrowerName: string;
+  } | null;
 };
 
 type SortField = "date" | "amount" | "category";
@@ -291,99 +298,106 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
     );
   };
 
-  const renderActions = (expense: Expense) => (
-    <div className="flex gap-1">
-      {(() => {
-        const receipts = getReceipts(expense);
-        if (receipts.length > 0) {
-          return (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-blue-600 hover:text-blue-700"
-                onClick={() => openReceiptViewer(expense.id)}
-                title={`View ${receipts.length} receipt(s)`}
-              >
-                <span className="relative">
-                  <IconPhoto className="h-4 w-4" />
-                  {receipts.length > 1 && (
-                    <span className="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-blue-600 text-[8px] text-white">
-                      {receipts.length}
-                    </span>
-                  )}
-                </span>
-              </Button>
-              <label className="cursor-pointer">
-                <input
-                  type="file"
-                  accept="image/*,.pdf"
-                  className="hidden"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) handleReceiptUpload(expense.id, file);
-                  }}
-                  disabled={uploadingExpenseId === expense.id}
-                />
+  const renderActions = (expense: Expense) => {
+    const isLoanExpense = !!expense.loanId;
+    return (
+      <div className="flex gap-1">
+        {(() => {
+          const receipts = getReceipts(expense);
+          if (receipts.length > 0) {
+            return (
+              <>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8"
-                  disabled={uploadingExpenseId === expense.id}
-                  asChild
+                  className="h-8 w-8 text-blue-600 hover:text-blue-700"
+                  onClick={() => openReceiptViewer(expense.id)}
+                  title={`View ${receipts.length} receipt(s)`}
                 >
-                  <span title="Add Receipt">
-                    <IconUpload className="h-4 w-4" />
+                  <span className="relative">
+                    <IconPhoto className="h-4 w-4" />
+                    {receipts.length > 1 && (
+                      <span className="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-blue-600 text-[8px] text-white">
+                        {receipts.length}
+                      </span>
+                    )}
                   </span>
                 </Button>
-              </label>
-            </>
+                <label className="cursor-pointer">
+                  <input
+                    type="file"
+                    accept="image/*,.pdf"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleReceiptUpload(expense.id, file);
+                    }}
+                    disabled={uploadingExpenseId === expense.id}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={uploadingExpenseId === expense.id}
+                    asChild
+                  >
+                    <span title="Add Receipt">
+                      <IconUpload className="h-4 w-4" />
+                    </span>
+                  </Button>
+                </label>
+              </>
+            );
+          }
+          return (
+            <label className="cursor-pointer">
+              <input
+                type="file"
+                accept="image/*,.pdf"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleReceiptUpload(expense.id, file);
+                }}
+                disabled={uploadingExpenseId === expense.id}
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                disabled={uploadingExpenseId === expense.id}
+                asChild
+              >
+                <span title="Upload Receipt">
+                  <IconUpload className="h-4 w-4" />
+                </span>
+              </Button>
+            </label>
           );
-        }
-        return (
-          <label className="cursor-pointer">
-            <input
-              type="file"
-              accept="image/*,.pdf"
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) handleReceiptUpload(expense.id, file);
-              }}
-              disabled={uploadingExpenseId === expense.id}
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              disabled={uploadingExpenseId === expense.id}
-              asChild
-            >
-              <span title="Upload Receipt">
-                <IconUpload className="h-4 w-4" />
-              </span>
-            </Button>
-          </label>
-        );
-      })()}
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-8 w-8"
-        onClick={() => openEditDialogSafe(expense)}
-      >
-        <IconEdit className="h-4 w-4" />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-8 w-8 text-destructive hover:text-destructive"
-        onClick={() => setDeletingExpense(expense)}
-      >
-        <IconTrash className="h-4 w-4" />
-      </Button>
-    </div>
-  );
+        })()}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => openEditDialogSafe(expense)}
+          disabled={isLoanExpense}
+          title={isLoanExpense ? "Managed via loan record" : "Edit"}
+        >
+          <IconEdit className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-destructive hover:text-destructive"
+          onClick={() => setDeletingExpense(expense)}
+          disabled={isLoanExpense}
+          title={isLoanExpense ? "Managed via loan record" : "Delete"}
+        >
+          <IconTrash className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  };
 
   return (
     <>
@@ -404,6 +418,22 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                     })}
                   </span>
                   <Badge variant="secondary" className="text-xs">{expense.category}</Badge>
+                  {expense.loanId && expense.loan && (
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] px-1.5 py-0 border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400"
+                    >
+                      Loan: {expense.loan.borrowerName}
+                    </Badge>
+                  )}
+                  {expense.amount < 0 && (
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] px-1.5 py-0 border-green-300 text-green-700 dark:border-green-700 dark:text-green-400"
+                    >
+                      Refund
+                    </Badge>
+                  )}
                   <span
                     className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium ${
                       sourceColors[expense.source] || "bg-gray-100 text-gray-800"
@@ -432,7 +462,11 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                   </div>
                 )}
               </div>
-              <p className="text-sm font-bold whitespace-nowrap">
+              <p
+                className={`text-sm font-bold whitespace-nowrap ${
+                  expense.amount < 0 ? "text-green-600" : ""
+                }`}
+              >
                 {formatCurrency(expense.amount)}
               </p>
             </div>
@@ -483,10 +517,30 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                   })}
                 </TableCell>
                 <TableCell className="font-medium">
-                  {expense.description || expense.merchant || "-"}
+                  <div className="flex flex-col gap-1">
+                    <span>{expense.description || expense.merchant || "-"}</span>
+                    {expense.loanId && expense.loan && (
+                      <Badge
+                        variant="outline"
+                        className="w-fit text-[10px] px-1.5 py-0 border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400"
+                      >
+                        Loan: {expense.loan.borrowerName}
+                      </Badge>
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell>
-                  <Badge variant="secondary">{expense.category}</Badge>
+                  <div className="flex flex-wrap items-center gap-1">
+                    <Badge variant="secondary">{expense.category}</Badge>
+                    {expense.amount < 0 && (
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] px-1.5 py-0 border-green-300 text-green-700 dark:border-green-700 dark:text-green-400"
+                      >
+                        Refund
+                      </Badge>
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell>
                   {expense.tags && expense.tags.length > 0 ? (
@@ -524,7 +578,11 @@ export function ExpenseTable({ expenses: initialExpenses, currency, accounts = [
                     <span className="text-muted-foreground">-</span>
                   )}
                 </TableCell>
-                <TableCell className="text-right font-medium">
+                <TableCell
+                  className={`text-right font-medium ${
+                    expense.amount < 0 ? "text-green-600" : ""
+                  }`}
+                >
                   {formatCurrency(expense.amount)}
                 </TableCell>
                 <TableCell className="text-right">

--- a/components/loan-list.tsx
+++ b/components/loan-list.tsx
@@ -52,6 +52,8 @@ import {
   IconUpload,
   IconX,
   IconPhoto,
+  IconWallet,
+  IconArrowBackUp,
 } from "@tabler/icons-react";
 import { addRepayment, deleteLoan, deleteRepayment, updateLoan, addRepaymentReceipt } from "@/lib/actions/loans";
 
@@ -61,6 +63,12 @@ type Repayment = {
   date: Date;
   note: string | null;
   receiptUrls: string[];
+};
+
+type AccountRef = {
+  id: string;
+  name: string;
+  type: string;
 };
 
 type Loan = {
@@ -75,6 +83,7 @@ type Loan = {
   description: string | null;
   receiptUrls: string[];
   repayments: Repayment[];
+  account?: AccountRef | null;
 };
 
 type LoanListProps = {
@@ -340,6 +349,12 @@ export function LoanList({ loans, currency }: LoanListProps) {
                       {loan.borrowerPhone}
                     </div>
                   )}
+                  {loan.account && (
+                    <div className="mt-0.5 text-xs text-muted-foreground flex items-center gap-1">
+                      <IconWallet className="h-3 w-3" />
+                      {loan.account.name}
+                    </div>
+                  )}
                 </div>
                 <div onClick={(e) => e.stopPropagation()}>
                   {renderLoanMenu(loan)}
@@ -380,6 +395,7 @@ export function LoanList({ loans, currency }: LoanListProps) {
               <TableHead>Repaid</TableHead>
               <TableHead>Progress</TableHead>
               <TableHead>Status</TableHead>
+              <TableHead>Account</TableHead>
               <TableHead>Lend Date</TableHead>
               <TableHead>Due Date</TableHead>
               <TableHead className="w-[50px]"></TableHead>
@@ -416,6 +432,16 @@ export function LoanList({ loans, currency }: LoanListProps) {
                     </div>
                   </TableCell>
                   <TableCell>{getStatusBadge(loan.status)}</TableCell>
+                  <TableCell>
+                    {loan.account ? (
+                      <div className="flex items-center gap-1 text-sm">
+                        <IconWallet className="h-3 w-3 text-muted-foreground" />
+                        {loan.account.name}
+                      </div>
+                    ) : (
+                      <span className="text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
                   <TableCell>{formatDate(loan.lendDate)}</TableCell>
                   <TableCell>
                     {loan.dueDate ? (
@@ -453,6 +479,16 @@ export function LoanList({ loans, currency }: LoanListProps) {
                 {selectedLoan && formatCurrency(selectedLoan.amount - selectedLoan.amountRepaid)}
               </div>
             </div>
+            {selectedLoan?.account && (
+              <div className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-300">
+                <div className="flex items-center gap-2">
+                  <IconArrowBackUp className="h-4 w-4" />
+                  <span>
+                    Repayment will be credited to <strong>{selectedLoan.account.name}</strong>
+                  </span>
+                </div>
+              </div>
+            )}
             <div className="grid gap-2">
               <Label htmlFor="repaymentAmount">Repayment Amount *</Label>
               <div className="relative">
@@ -622,7 +658,10 @@ export function LoanList({ loans, currency }: LoanListProps) {
             <DialogTitle>Delete Record?</DialogTitle>
             <AlertDialogDescription>
               This will permanently delete the lent money record to {selectedLoan?.borrowerName} and all its repayment records.
-              This action cannot be undone.
+              {selectedLoan?.account && (
+                <> Any associated balance changes on <strong>{selectedLoan.account.name}</strong> will be reversed.</>
+              )}
+              {" "}This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -686,6 +725,12 @@ export function LoanList({ loans, currency }: LoanListProps) {
                   <div className="flex items-center gap-2">
                     <IconPhone className="h-4 w-4 text-muted-foreground" />
                     <span>{selectedLoan.borrowerPhone}</span>
+                  </div>
+                )}
+                {selectedLoan.account && (
+                  <div className="flex items-center gap-2">
+                    <IconWallet className="h-4 w-4 text-muted-foreground" />
+                    <span>From: {selectedLoan.account.name}</span>
                   </div>
                 )}
               </div>

--- a/components/receipt-gallery.tsx
+++ b/components/receipt-gallery.tsx
@@ -43,6 +43,7 @@ const CATEGORIES = [
     "Education",
     "Investments",
     "Subscription",
+    "Lent Money",
     "General",
 ];
 

--- a/components/settings-form.tsx
+++ b/components/settings-form.tsx
@@ -63,6 +63,9 @@ const categories = [
   "Shopping",
   "Health",
   "Education",
+  "Investments",
+  "Subscription",
+  "Lent Money",
   "General",
 ];
 

--- a/lib/actions/expenses.ts
+++ b/lib/actions/expenses.ts
@@ -18,6 +18,7 @@ const EXPENSE_CATEGORIES = [
   "Education",
   "Investments",
   "Subscription",
+  "Lent Money",
   "General",
 ] as const;
 
@@ -243,7 +244,15 @@ export async function getExpenses(options?: z.infer<typeof GetExpensesOptionsSch
 
   const expenses = await db.expense.findMany({
     where,
-    include: { tags: { include: { tag: true } } },
+    include: {
+      tags: { include: { tag: true } },
+      loan: {
+        select: {
+          id: true,
+          borrowerName: true,
+        },
+      },
+    },
     orderBy: [
       { createdAt: "desc" },
       { id: "desc" },

--- a/lib/actions/loans.ts
+++ b/lib/actions/loans.ts
@@ -14,6 +14,7 @@ const CreateLoanSchema = z.object({
   lendDate: z.date(),
   dueDate: z.date().optional(),
   description: z.string().max(500).optional(),
+  accountId: z.string().uuid().optional(),
 });
 
 const UpdateLoanSchema = CreateLoanSchema.partial();
@@ -35,25 +36,93 @@ const IdSchema = z.string().uuid();
 export type CreateLoanInput = z.infer<typeof CreateLoanSchema>;
 export type AddRepaymentInput = z.infer<typeof AddRepaymentSchema>;
 
+type TxClient = Parameters<Parameters<typeof db.$transaction>[0]>[0];
+
+// For credit cards, spending increases the outstanding balance.
+// For all other account types, spending decreases the balance.
+// Negative amounts (e.g., refunds) reverse the effect naturally.
+function getBalanceAdjustment(accountType: string, amount: number): number {
+  if (accountType === "CREDIT_CARD") {
+    return amount;
+  }
+  return -amount;
+}
+
+async function recordBalanceHistory(
+  tx: TxClient,
+  accountId: string,
+  newBalance: number,
+  note: string,
+  date: Date
+) {
+  await tx.balanceHistory.create({
+    data: {
+      accountId,
+      balance: newBalance,
+      note,
+      date,
+    },
+  });
+}
+
 export async function createLoan(input: CreateLoanInput) {
   const { userId } = await auth();
   if (!userId) throw new Error("Unauthorized");
 
   const validated = CreateLoanSchema.parse(input);
 
-  const loan = await db.loan.create({
-    data: {
-      userId,
-      borrowerName: validated.borrowerName,
-      borrowerPhone: validated.borrowerPhone,
-      amount: validated.amount,
-      lendDate: validated.lendDate,
-      dueDate: validated.dueDate,
-      description: validated.description,
-    },
+  const loan = await db.$transaction(async (tx) => {
+    const created = await tx.loan.create({
+      data: {
+        userId,
+        borrowerName: validated.borrowerName,
+        borrowerPhone: validated.borrowerPhone,
+        amount: validated.amount,
+        lendDate: validated.lendDate,
+        dueDate: validated.dueDate,
+        description: validated.description,
+        accountId: validated.accountId,
+      },
+    });
+
+    if (validated.accountId) {
+      const account = await tx.account.findUnique({ where: { id: validated.accountId } });
+      if (account) {
+        await tx.expense.create({
+          data: {
+            userId,
+            amount: validated.amount,
+            category: "Lent Money",
+            description: `Lent to ${validated.borrowerName}${validated.description ? ` — ${validated.description}` : ""}`,
+            date: validated.lendDate,
+            accountId: validated.accountId,
+            loanId: created.id,
+            paymentMethod: account.name,
+          },
+        });
+
+        const adjustment = getBalanceAdjustment(account.type, validated.amount);
+        const updatedAccount = await tx.account.update({
+          where: { id: validated.accountId },
+          data: { currentBalance: { increment: adjustment } },
+        });
+        await recordBalanceHistory(
+          tx,
+          validated.accountId,
+          updatedAccount.currentBalance,
+          `Loan given to ${validated.borrowerName} (₹${validated.amount})`,
+          validated.lendDate
+        );
+      }
+    }
+
+    return created;
   });
 
   revalidatePath("/loans");
+  revalidatePath("/expenses");
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
   return loan;
 }
 
@@ -86,6 +155,13 @@ export async function getLoans(options?: z.infer<typeof GetLoansOptionsSchema>) 
       repayments: {
         orderBy: { date: "desc" },
       },
+      account: {
+        select: {
+          id: true,
+          name: true,
+          type: true,
+        },
+      },
     },
     orderBy: [
       { status: "asc" }, // PENDING first, then PARTIAL, then COMPLETED
@@ -107,6 +183,13 @@ export async function getLoan(id: string) {
     include: {
       repayments: {
         orderBy: { date: "desc" },
+      },
+      account: {
+        select: {
+          id: true,
+          name: true,
+          type: true,
+        },
       },
     },
   });
@@ -153,18 +236,45 @@ export async function deleteLoan(id: string) {
 
   const validatedId = IdSchema.parse(id);
 
-  // Verify ownership
-  const existing = await db.loan.findFirst({
-    where: { id: validatedId, userId },
-  });
+  await db.$transaction(async (tx) => {
+    const existing = await db.loan.findFirst({ where: { id: validatedId, userId } });
+    if (!existing) throw new Error("Loan not found");
 
-  if (!existing) throw new Error("Loan not found");
+    const linkedExpenses = await tx.expense.findMany({
+      where: { loanId: validatedId, userId },
+    });
 
-  await db.loan.delete({
-    where: { id: validatedId },
+    for (const expense of linkedExpenses) {
+      if (expense.accountId) {
+        const account = await tx.account.findUnique({ where: { id: expense.accountId } });
+        if (account) {
+          const reversal = -getBalanceAdjustment(account.type, expense.amount);
+          const updatedAccount = await tx.account.update({
+            where: { id: expense.accountId },
+            data: { currentBalance: { increment: reversal } },
+          });
+          await recordBalanceHistory(
+            tx,
+            expense.accountId,
+            updatedAccount.currentBalance,
+            `Loan to ${existing.borrowerName} reversed (₹${expense.amount})`,
+            expense.date
+          );
+        }
+      }
+    }
+
+    await tx.expense.deleteMany({ where: { loanId: validatedId } });
+
+    await tx.loan.delete({
+      where: { id: validatedId },
+    });
   });
 
   revalidatePath("/loans");
+  revalidatePath("/expenses");
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
 }
 
 export async function addRepayment(input: AddRepaymentInput) {
@@ -173,42 +283,75 @@ export async function addRepayment(input: AddRepaymentInput) {
 
   const validated = AddRepaymentSchema.parse(input);
 
-  // Verify loan ownership
-  const loan = await db.loan.findFirst({
-    where: { id: validated.loanId, userId },
-  });
+  const repayment = await db.$transaction(async (tx) => {
+    const loan = await tx.loan.findFirst({ where: { id: validated.loanId, userId } });
+    if (!loan) throw new Error("Loan not found");
 
-  if (!loan) throw new Error("Loan not found");
+    const created = await tx.repayment.create({
+      data: {
+        loanId: validated.loanId,
+        amount: validated.amount,
+        date: validated.date,
+        note: validated.note,
+      },
+    });
 
-  // Create repayment
-  const repayment = await db.repayment.create({
-    data: {
-      loanId: validated.loanId,
-      amount: validated.amount,
-      date: validated.date,
-      note: validated.note,
-    },
-  });
+    const newAmountRepaid = loan.amountRepaid + validated.amount;
+    let newStatus: "PENDING" | "PARTIAL" | "COMPLETED" = "PENDING";
 
-  // Update loan's amountRepaid and status
-  const newAmountRepaid = loan.amountRepaid + validated.amount;
-  let newStatus: "PENDING" | "PARTIAL" | "COMPLETED" = "PENDING";
+    if (newAmountRepaid >= loan.amount) {
+      newStatus = "COMPLETED";
+    } else if (newAmountRepaid > 0) {
+      newStatus = "PARTIAL";
+    }
 
-  if (newAmountRepaid >= loan.amount) {
-    newStatus = "COMPLETED";
-  } else if (newAmountRepaid > 0) {
-    newStatus = "PARTIAL";
-  }
+    await tx.loan.update({
+      where: { id: validated.loanId },
+      data: {
+        amountRepaid: newAmountRepaid,
+        status: newStatus,
+      },
+    });
 
-  await db.loan.update({
-    where: { id: validated.loanId },
-    data: {
-      amountRepaid: newAmountRepaid,
-      status: newStatus,
-    },
+    if (loan.accountId) {
+      const account = await tx.account.findUnique({ where: { id: loan.accountId } });
+      if (account) {
+        await tx.expense.create({
+          data: {
+            userId,
+            amount: -validated.amount,
+            category: "Lent Money",
+            description: `Repayment from ${loan.borrowerName}${validated.note ? ` — ${validated.note}` : ""}`,
+            date: validated.date,
+            accountId: loan.accountId,
+            loanId: loan.id,
+            repaymentId: created.id,
+            paymentMethod: account.name,
+          },
+        });
+
+        const adjustment = getBalanceAdjustment(account.type, -validated.amount);
+        const updatedAccount = await tx.account.update({
+          where: { id: loan.accountId },
+          data: { currentBalance: { increment: adjustment } },
+        });
+        await recordBalanceHistory(
+          tx,
+          loan.accountId,
+          updatedAccount.currentBalance,
+          `Loan repayment from ${loan.borrowerName} (₹${validated.amount})`,
+          validated.date
+        );
+      }
+    }
+
+    return created;
   });
 
   revalidatePath("/loans");
+  revalidatePath("/expenses");
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
   return repayment;
 }
 
@@ -218,43 +361,61 @@ export async function deleteRepayment(repaymentId: string) {
 
   const validatedId = IdSchema.parse(repaymentId);
 
-  // Get repayment with loan
-  const repayment = await db.repayment.findUnique({
-    where: { id: validatedId },
-    include: { loan: true },
-  });
+  await db.$transaction(async (tx) => {
+    const repayment = await tx.repayment.findUnique({
+      where: { id: validatedId },
+      include: { loan: true },
+    });
 
-  if (!repayment) throw new Error("Repayment not found");
+    if (!repayment) throw new Error("Repayment not found");
+    if (repayment.loan.userId !== userId) throw new Error("Unauthorized");
 
-  // Verify loan ownership
-  if (repayment.loan.userId !== userId) {
-    throw new Error("Unauthorized");
-  }
+    const refundExpense = await tx.expense.findFirst({ where: { repaymentId: validatedId } });
+    if (refundExpense?.accountId) {
+      const account = await tx.account.findUnique({ where: { id: refundExpense.accountId } });
+      if (account) {
+        const reversal = -getBalanceAdjustment(account.type, refundExpense.amount);
+        const updatedAccount = await tx.account.update({
+          where: { id: refundExpense.accountId },
+          data: { currentBalance: { increment: reversal } },
+        });
+        await recordBalanceHistory(
+          tx,
+          refundExpense.accountId,
+          updatedAccount.currentBalance,
+          `Loan repayment reversed from ${repayment.loan.borrowerName} (₹${repayment.amount})`,
+          refundExpense.date
+        );
+      }
+    }
+    if (refundExpense) {
+      await tx.expense.delete({ where: { id: refundExpense.id } });
+    }
 
-  // Delete repayment
-  await db.repayment.delete({
-    where: { id: validatedId },
-  });
+    await tx.repayment.delete({ where: { id: validatedId } });
 
-  // Update loan's amountRepaid and status
-  const newAmountRepaid = repayment.loan.amountRepaid - repayment.amount;
-  let newStatus: "PENDING" | "PARTIAL" | "COMPLETED" = "PENDING";
+    const newAmountRepaid = Math.max(0, repayment.loan.amountRepaid - repayment.amount);
+    let newStatus: "PENDING" | "PARTIAL" | "COMPLETED" = "PENDING";
 
-  if (newAmountRepaid >= repayment.loan.amount) {
-    newStatus = "COMPLETED";
-  } else if (newAmountRepaid > 0) {
-    newStatus = "PARTIAL";
-  }
+    if (newAmountRepaid >= repayment.loan.amount) {
+      newStatus = "COMPLETED";
+    } else if (newAmountRepaid > 0) {
+      newStatus = "PARTIAL";
+    }
 
-  await db.loan.update({
-    where: { id: repayment.loanId },
-    data: {
-      amountRepaid: Math.max(0, newAmountRepaid),
-      status: newStatus,
-    },
+    await tx.loan.update({
+      where: { id: repayment.loanId },
+      data: {
+        amountRepaid: newAmountRepaid,
+        status: newStatus,
+      },
+    });
   });
 
   revalidatePath("/loans");
+  revalidatePath("/expenses");
+  revalidatePath("/accounts");
+  revalidatePath("/dashboard");
 }
 
 const AddReceiptSchema = z.object({

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,10 @@ model Expense {
   paymentMethod String?        // Account name label (for display)
   accountId     String?        // Linked account for balance tracking
   account       Account?       @relation(fields: [accountId], references: [id], onDelete: SetNull)
+  loanId        String?        // Linked loan (for loan expense AND repayment refund)
+  loan          Loan?          @relation(fields: [loanId], references: [id], onDelete: SetNull)
+  repaymentId   String?        // Linked repayment (for refund expenses)
+  repayment     Repayment?     @relation(fields: [repaymentId], references: [id], onDelete: SetNull)
   date          DateTime       @default(now())
   isVerified    Boolean        @default(false) // True if matched with Bank Statement
   metadata      Json?          // Stores raw OCR text or debug info
@@ -49,6 +53,8 @@ model Expense {
   @@index([userId])
   @@index([date])
   @@index([accountId])
+  @@index([loanId])
+  @@index([repaymentId])
 }
 
 model Tag {
@@ -136,12 +142,16 @@ model Loan {
   dueDate       DateTime?    // Optional due date
   description   String?      // Notes about the loan
   receiptUrls   String[]     @default([]) // Receipts/proof
+  accountId     String?      // Which account the money was lent from
+  account       Account?     @relation(fields: [accountId], references: [id], onDelete: SetNull)
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
   repayments    Repayment[]
+  expenses      Expense[]
 
   @@index([userId])
   @@index([borrowerName])
+  @@index([accountId])
 }
 
 model Repayment {
@@ -153,6 +163,7 @@ model Repayment {
   note        String?
   receiptUrls String[] @default([]) // Receipts for this repayment
   createdAt   DateTime @default(now())
+  expenses    Expense[]
 
   @@index([loanId])
 }
@@ -185,6 +196,7 @@ model Account {
   updatedAt     DateTime        @updatedAt
   balanceHistory BalanceHistory[]
   expenses      Expense[]
+  loans         Loan[]
   investmentProductsList InvestmentProduct[] // Investment products linked to this account
   transfersFrom Transfer[]      @relation("TransferFrom")
   transfersTo   Transfer[]      @relation("TransferTo")

--- a/tests/unit/actions/expenses.test.ts
+++ b/tests/unit/actions/expenses.test.ts
@@ -763,6 +763,7 @@ describe("Expense Validation", () => {
             "Education",
             "Investments",
             "Subscription",
+            "Lent Money",
             "General",
         ];
 

--- a/tests/unit/actions/loans.test.ts
+++ b/tests/unit/actions/loans.test.ts
@@ -1,42 +1,72 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const UUIDS = {
-    loan1: "c1111111-1111-1111-a111-111111111111",
-    loan2: "d2222222-2222-2222-8aaa-aaaaaaaaaaaa",
-    repayment1: "e3333333-3333-3333-9bbb-bbbbbbbbbbbb",
+    loan1: "c1111111-1111-4111-a111-111111111111",
+    loan2: "d2222222-2222-4222-8aaa-aaaaaaaaaaaa",
+    repayment1: "e3333333-3333-4333-9bbb-bbbbbbbbbbbb",
     repayment2: "f4444444-4444-4444-accc-cccccccccccc",
+    accountBank: "ab111111-4111-4111-a111-111111111111",
+    accountCard: "ac222222-4222-4222-8222-222222222222",
+    expense1: "ea111111-4111-4111-a111-111111111111",
+    expense2: "ea222222-4222-4222-a222-222222222222",
+    history1: "bh111111-4111-4111-a111-111111111111",
+    history2: "bh222222-4222-4222-a222-222222222222",
 };
 
-// Mock the database client
+// Build a mock for the db that supports $transaction
+const buildModelMock = () => ({
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+    aggregate: vi.fn(),
+    upsert: vi.fn(),
+    count: vi.fn(),
+});
+
 const mockDb = {
-    loan: {
-        create: vi.fn(),
-        findMany: vi.fn(),
-        findUnique: vi.fn(),
-        findFirst: vi.fn(),
-        update: vi.fn(),
-        delete: vi.fn(),
-        aggregate: vi.fn(),
-    },
-    repayment: {
-        create: vi.fn(),
-        findMany: vi.fn(),
-        findUnique: vi.fn(),
-        delete: vi.fn(),
-    },
+    loan: buildModelMock(),
+    repayment: buildModelMock(),
+    account: buildModelMock(),
+    expense: buildModelMock(),
+    balanceHistory: buildModelMock(),
+    $transaction: vi.fn(),
 };
 
 vi.mock("@/lib/db", () => ({
     db: mockDb,
 }));
 
+// Mock next/cache's revalidatePath so we don't try to call Next internals
+vi.mock("next/cache", () => ({
+    revalidatePath: vi.fn(),
+}));
+
+// Helper: make $transaction execute the callback with `tx` that mirrors db models
+const setupTransactionMock = () => {
+    mockDb.$transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) => {
+        const tx = {
+            loan: mockDb.loan,
+            repayment: mockDb.repayment,
+            account: mockDb.account,
+            expense: mockDb.expense,
+            balanceHistory: mockDb.balanceHistory,
+        };
+        return cb(tx as unknown as typeof mockDb);
+    });
+};
+
 describe("Loan Actions", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        setupTransactionMock();
     });
 
     describe("createLoan", () => {
-        it("should create a loan with required fields", async () => {
+        it("should create a loan with required fields (no account)", async () => {
             const mockLoan = {
                 id: UUIDS.loan1,
                 userId: "test-user-id",
@@ -49,6 +79,7 @@ describe("Loan Actions", () => {
                 dueDate: null,
                 description: "Personal loan",
                 receiptUrls: [],
+                accountId: null,
                 createdAt: new Date(),
                 updatedAt: new Date(),
             };
@@ -68,17 +99,121 @@ describe("Loan Actions", () => {
 
             expect(result).toEqual(mockLoan);
             expect(mockDb.loan.create).toHaveBeenCalledTimes(1);
+            expect(mockDb.expense.create).not.toHaveBeenCalled();
+            expect(mockDb.account.update).not.toHaveBeenCalled();
+        });
+
+        it("should create a loan with BANK account and deduct balance", async () => {
+            const mockLoan = {
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John Doe",
+                amount: 5000,
+                amountRepaid: 0,
+                status: "PENDING",
+                lendDate: new Date(),
+                accountId: UUIDS.accountBank,
+            };
+
+            const mockAccount = {
+                id: UUIDS.accountBank,
+                userId: "test-user-id",
+                name: "SBI Savings",
+                type: "BANK",
+                currentBalance: 10000,
+            };
+
+            mockDb.loan.create.mockResolvedValue(mockLoan);
+            mockDb.account.findUnique.mockResolvedValue(mockAccount);
+            mockDb.expense.create.mockResolvedValue({ id: UUIDS.expense1, amount: 5000 });
+            mockDb.account.update.mockResolvedValue({ ...mockAccount, currentBalance: 5000 });
+            mockDb.balanceHistory.create.mockResolvedValue({ id: UUIDS.history1 });
+
+            vi.resetModules();
+            const { createLoan } = await import("@/lib/actions/loans");
+
+            const result = await createLoan({
+                borrowerName: "John Doe",
+                amount: 5000,
+                lendDate: new Date(),
+                accountId: UUIDS.accountBank,
+            });
+
+            expect(result).toEqual(mockLoan);
+            expect(mockDb.expense.create).toHaveBeenCalledTimes(1);
+            expect(mockDb.expense.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        amount: 5000,
+                        category: "Lent Money",
+                        loanId: UUIDS.loan1,
+                        accountId: UUIDS.accountBank,
+                    }),
+                })
+            );
+            expect(mockDb.account.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: UUIDS.accountBank },
+                    data: { currentBalance: { increment: -5000 } },
+                })
+            );
+            expect(mockDb.balanceHistory.create).toHaveBeenCalledTimes(1);
+        });
+
+        it("should create a loan with CREDIT_CARD account and increase debt", async () => {
+            const mockLoan = {
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John Doe",
+                amount: 5000,
+                amountRepaid: 0,
+                status: "PENDING",
+                lendDate: new Date(),
+                accountId: UUIDS.accountCard,
+            };
+
+            const mockAccount = {
+                id: UUIDS.accountCard,
+                userId: "test-user-id",
+                name: "HDFC Credit Card",
+                type: "CREDIT_CARD",
+                currentBalance: 0,
+            };
+
+            mockDb.loan.create.mockResolvedValue(mockLoan);
+            mockDb.account.findUnique.mockResolvedValue(mockAccount);
+            mockDb.expense.create.mockResolvedValue({ id: UUIDS.expense1, amount: 5000 });
+            mockDb.account.update.mockResolvedValue({ ...mockAccount, currentBalance: 5000 });
+            mockDb.balanceHistory.create.mockResolvedValue({ id: UUIDS.history1 });
+
+            vi.resetModules();
+            const { createLoan } = await import("@/lib/actions/loans");
+
+            await createLoan({
+                borrowerName: "John Doe",
+                amount: 5000,
+                lendDate: new Date(),
+                accountId: UUIDS.accountCard,
+            });
+
+            expect(mockDb.account.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: UUIDS.accountCard },
+                    data: { currentBalance: { increment: 5000 } },
+                })
+            );
         });
     });
 
     describe("addRepayment", () => {
-        it("should add repayment and update loan", async () => {
+        it("should add repayment, update loan, and skip account ops when no account", async () => {
             const mockLoan = {
                 id: UUIDS.loan1,
                 userId: "test-user-id",
                 amount: 5000,
                 amountRepaid: 0,
                 status: "PENDING",
+                accountId: null,
             };
 
             const mockRepayment = {
@@ -111,11 +246,123 @@ describe("Loan Actions", () => {
 
             expect(result.id).toBe(UUIDS.repayment1);
             expect(result.amount).toBe(2000);
-            expect(mockDb.loan.update).toHaveBeenCalledWith(
+            expect(mockDb.expense.create).not.toHaveBeenCalled();
+            expect(mockDb.account.update).not.toHaveBeenCalled();
+        });
+
+        it("should create negative refund expense and credit balance for linked BANK account", async () => {
+            const mockLoan = {
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John Doe",
+                amount: 5000,
+                amountRepaid: 0,
+                status: "PENDING",
+                accountId: UUIDS.accountBank,
+            };
+
+            const mockAccount = {
+                id: UUIDS.accountBank,
+                name: "SBI Savings",
+                type: "BANK",
+                currentBalance: 5000,
+            };
+
+            const mockRepayment = {
+                id: UUIDS.repayment1,
+                loanId: UUIDS.loan1,
+                amount: 2000,
+                date: new Date(),
+                note: "First payment",
+                receiptUrls: [],
+                createdAt: new Date(),
+            };
+
+            mockDb.loan.findFirst.mockResolvedValue(mockLoan);
+            mockDb.repayment.create.mockResolvedValue(mockRepayment);
+            mockDb.account.findUnique.mockResolvedValue(mockAccount);
+            mockDb.expense.create.mockResolvedValue({ id: UUIDS.expense1, amount: -2000 });
+            mockDb.account.update.mockResolvedValue({ ...mockAccount, currentBalance: 7000 });
+            mockDb.balanceHistory.create.mockResolvedValue({ id: UUIDS.history1 });
+            mockDb.loan.update.mockResolvedValue({ ...mockLoan, amountRepaid: 2000, status: "PARTIAL" });
+
+            vi.resetModules();
+            const { addRepayment } = await import("@/lib/actions/loans");
+
+            await addRepayment({
+                loanId: UUIDS.loan1,
+                amount: 2000,
+                date: new Date(),
+                note: "First payment",
+            });
+
+            expect(mockDb.expense.create).toHaveBeenCalledWith(
                 expect.objectContaining({
                     data: expect.objectContaining({
-                        status: "PARTIAL",
+                        amount: -2000,
+                        category: "Lent Money",
+                        loanId: UUIDS.loan1,
+                        repaymentId: UUIDS.repayment1,
+                        accountId: UUIDS.accountBank,
                     }),
+                })
+            );
+            expect(mockDb.account.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: UUIDS.accountBank },
+                    data: { currentBalance: { increment: 2000 } },
+                })
+            );
+        });
+
+        it("should reduce debt when repayment on CREDIT_CARD linked loan", async () => {
+            const mockLoan = {
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John Doe",
+                amount: 5000,
+                amountRepaid: 0,
+                status: "PENDING",
+                accountId: UUIDS.accountCard,
+            };
+
+            const mockAccount = {
+                id: UUIDS.accountCard,
+                name: "HDFC Credit Card",
+                type: "CREDIT_CARD",
+                currentBalance: 5000,
+            };
+
+            const mockRepayment = {
+                id: UUIDS.repayment1,
+                loanId: UUIDS.loan1,
+                amount: 2000,
+                date: new Date(),
+                receiptUrls: [],
+                createdAt: new Date(),
+            };
+
+            mockDb.loan.findFirst.mockResolvedValue(mockLoan);
+            mockDb.repayment.create.mockResolvedValue(mockRepayment);
+            mockDb.account.findUnique.mockResolvedValue(mockAccount);
+            mockDb.expense.create.mockResolvedValue({ id: UUIDS.expense1, amount: -2000 });
+            mockDb.account.update.mockResolvedValue({ ...mockAccount, currentBalance: 3000 });
+            mockDb.balanceHistory.create.mockResolvedValue({ id: UUIDS.history1 });
+            mockDb.loan.update.mockResolvedValue({ ...mockLoan, amountRepaid: 2000, status: "PARTIAL" });
+
+            vi.resetModules();
+            const { addRepayment } = await import("@/lib/actions/loans");
+
+            await addRepayment({
+                loanId: UUIDS.loan1,
+                amount: 2000,
+                date: new Date(),
+            });
+
+            expect(mockDb.account.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: UUIDS.accountCard },
+                    data: { currentBalance: { increment: -2000 } },
                 })
             );
         });
@@ -124,9 +371,11 @@ describe("Loan Actions", () => {
             const mockLoan = {
                 id: UUIDS.loan1,
                 userId: "test-user-id",
+                borrowerName: "John Doe",
                 amount: 5000,
                 amountRepaid: 3000,
                 status: "PARTIAL",
+                accountId: null,
             };
 
             mockDb.loan.findFirst.mockResolvedValue(mockLoan);
@@ -135,7 +384,6 @@ describe("Loan Actions", () => {
                 loanId: UUIDS.loan1,
                 amount: 2000,
                 date: new Date(),
-                note: "Final payment",
                 receiptUrls: [],
                 createdAt: new Date(),
             });
@@ -152,7 +400,6 @@ describe("Loan Actions", () => {
                 loanId: UUIDS.loan1,
                 amount: 2000,
                 date: new Date(),
-                note: "Final payment",
             });
 
             expect(mockDb.loan.update).toHaveBeenCalledWith(
@@ -165,8 +412,180 @@ describe("Loan Actions", () => {
         });
     });
 
+    describe("deleteLoan", () => {
+        it("should delete a loan with no linked expenses", async () => {
+            mockDb.loan.findFirst.mockResolvedValue({
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John",
+            });
+            mockDb.expense.findMany.mockResolvedValue([]);
+            mockDb.loan.delete.mockResolvedValue({ id: UUIDS.loan1 });
+
+            vi.resetModules();
+            const { deleteLoan } = await import("@/lib/actions/loans");
+            await deleteLoan(UUIDS.loan1);
+
+            expect(mockDb.expense.deleteMany).toHaveBeenCalledWith({
+                where: { loanId: UUIDS.loan1 },
+            });
+            expect(mockDb.loan.delete).toHaveBeenCalledWith({
+                where: { id: UUIDS.loan1 },
+            });
+        });
+
+        it("should reverse balance for each linked expense on BANK account", async () => {
+            mockDb.loan.findFirst.mockResolvedValue({
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John",
+            });
+            mockDb.expense.findMany.mockResolvedValue([
+                { id: UUIDS.expense1, accountId: UUIDS.accountBank, amount: 5000, date: new Date() },
+            ]);
+            mockDb.account.findUnique.mockResolvedValue({
+                id: UUIDS.accountBank,
+                type: "BANK",
+                currentBalance: 0,
+            });
+            mockDb.account.update.mockResolvedValue({ currentBalance: 5000 });
+            mockDb.balanceHistory.create.mockResolvedValue({});
+
+            vi.resetModules();
+            const { deleteLoan } = await import("@/lib/actions/loans");
+            await deleteLoan(UUIDS.loan1);
+
+            expect(mockDb.account.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: UUIDS.accountBank },
+                    data: { currentBalance: { increment: 5000 } },
+                })
+            );
+            expect(mockDb.expense.deleteMany).toHaveBeenCalled();
+            expect(mockDb.loan.delete).toHaveBeenCalled();
+        });
+
+        it("should reverse balance for repayment refund expense", async () => {
+            mockDb.loan.findFirst.mockResolvedValue({
+                id: UUIDS.loan1,
+                userId: "test-user-id",
+                borrowerName: "John",
+            });
+            mockDb.expense.findMany.mockResolvedValue([
+                { id: UUIDS.expense1, accountId: UUIDS.accountBank, amount: 5000, date: new Date() },
+                { id: UUIDS.expense2, accountId: UUIDS.accountBank, amount: -2000, date: new Date() },
+            ]);
+            mockDb.account.findUnique.mockResolvedValue({
+                id: UUIDS.accountBank,
+                type: "BANK",
+                currentBalance: 3000,
+            });
+            mockDb.account.update.mockResolvedValue({ currentBalance: 5000 });
+            mockDb.balanceHistory.create.mockResolvedValue({});
+
+            vi.resetModules();
+            const { deleteLoan } = await import("@/lib/actions/loans");
+            await deleteLoan(UUIDS.loan1);
+
+            // First expense: reversal of +5000 for BANK is +5000
+            // Second expense: reversal of -2000 for BANK is -2000
+            expect(mockDb.account.update).toHaveBeenNthCalledWith(
+                1,
+                expect.objectContaining({
+                    data: { currentBalance: { increment: 5000 } },
+                })
+            );
+            expect(mockDb.account.update).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({
+                    data: { currentBalance: { increment: -2000 } },
+                })
+            );
+        });
+    });
+
+    describe("deleteRepayment", () => {
+        it("should remove repayment and reverse refund expense + balance", async () => {
+            const mockRepayment = {
+                id: UUIDS.repayment1,
+                loanId: UUIDS.loan1,
+                amount: 2000,
+                loan: {
+                    id: UUIDS.loan1,
+                    userId: "test-user-id",
+                    borrowerName: "John",
+                    amount: 5000,
+                    amountRepaid: 2000,
+                },
+            };
+
+            mockDb.repayment.findUnique.mockResolvedValue(mockRepayment);
+            mockDb.expense.findFirst.mockResolvedValue({
+                id: UUIDS.expense1,
+                accountId: UUIDS.accountBank,
+                amount: -2000,
+                date: new Date(),
+            });
+            mockDb.account.findUnique.mockResolvedValue({
+                id: UUIDS.accountBank,
+                type: "BANK",
+                currentBalance: 7000,
+            });
+            mockDb.account.update.mockResolvedValue({ currentBalance: 5000 });
+            mockDb.balanceHistory.create.mockResolvedValue({});
+
+            vi.resetModules();
+            const { deleteRepayment } = await import("@/lib/actions/loans");
+            await deleteRepayment(UUIDS.repayment1);
+
+            expect(mockDb.expense.delete).toHaveBeenCalledWith({
+                where: { id: UUIDS.expense1 },
+            });
+            expect(mockDb.repayment.delete).toHaveBeenCalledWith({
+                where: { id: UUIDS.repayment1 },
+            });
+            // Reversal of -2000 for BANK is +2000... wait
+            // adjustment for refund of 2000 = -(-2000) = 2000? No
+            // original = -validated.amount = -2000
+            // adjustment at create = getBalanceAdjustment(BANK, -2000) = -(-2000) = +2000
+            // reversal = -getBalanceAdjustment(BANK, -2000) = -2000
+            // So balance -= 2000
+            expect(mockDb.account.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: { currentBalance: { increment: -2000 } },
+                })
+            );
+        });
+
+        it("should handle repayment deletion with no linked expense", async () => {
+            const mockRepayment = {
+                id: UUIDS.repayment1,
+                loanId: UUIDS.loan1,
+                amount: 2000,
+                loan: {
+                    id: UUIDS.loan1,
+                    userId: "test-user-id",
+                    borrowerName: "John",
+                    amount: 5000,
+                    amountRepaid: 2000,
+                },
+            };
+
+            mockDb.repayment.findUnique.mockResolvedValue(mockRepayment);
+            mockDb.expense.findFirst.mockResolvedValue(null);
+
+            vi.resetModules();
+            const { deleteRepayment } = await import("@/lib/actions/loans");
+            await deleteRepayment(UUIDS.repayment1);
+
+            expect(mockDb.account.update).not.toHaveBeenCalled();
+            expect(mockDb.expense.delete).not.toHaveBeenCalled();
+            expect(mockDb.repayment.delete).toHaveBeenCalled();
+        });
+    });
+
     describe("getLoans", () => {
-        it("should return all loans with repayments", async () => {
+        it("should return all loans with repayments and account info", async () => {
             const mockLoans = [
                 {
                     id: UUIDS.loan1,
@@ -175,6 +594,7 @@ describe("Loan Actions", () => {
                     amountRepaid: 2000,
                     status: "PARTIAL",
                     repayments: [{ id: UUIDS.repayment1, amount: 2000 }],
+                    account: { id: UUIDS.accountBank, name: "SBI Savings", type: "BANK" },
                 },
                 {
                     id: UUIDS.loan2,
@@ -183,6 +603,7 @@ describe("Loan Actions", () => {
                     amountRepaid: 0,
                     status: "PENDING",
                     repayments: [],
+                    account: null,
                 },
             ];
 
@@ -194,6 +615,14 @@ describe("Loan Actions", () => {
 
             expect(result).toHaveLength(2);
             expect(result[0].repayments).toHaveLength(1);
+            expect(result[0].account?.name).toBe("SBI Savings");
+            expect(mockDb.loan.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    include: expect.objectContaining({
+                        account: expect.any(Object),
+                    }),
+                })
+            );
         });
 
         it("should filter by status", async () => {
@@ -230,24 +659,6 @@ describe("Loan Actions", () => {
             expect(result.totalLent).toBe(18000);
             expect(result.totalRepaid).toBe(5000);
             expect(result.totalOutstanding).toBe(13000);
-        });
-    });
-
-    describe("deleteLoan", () => {
-        it("should delete a loan", async () => {
-            mockDb.loan.findFirst.mockResolvedValue({
-                id: UUIDS.loan1,
-                userId: "test-user-id",
-            });
-            mockDb.loan.delete.mockResolvedValue({ id: UUIDS.loan1 });
-
-            vi.resetModules();
-            const { deleteLoan } = await import("@/lib/actions/loans");
-            await deleteLoan(UUIDS.loan1);
-
-            expect(mockDb.loan.delete).toHaveBeenCalledWith({
-                where: { id: UUIDS.loan1 },
-            });
         });
     });
 });


### PR DESCRIPTION
- Add accountId to Loan model (SetNull on account delete)
- Add loanId + repaymentId to Expense model (back-link to loan)
- Add 'Lent Money' to EXPENSE_CATEGORIES
- Add back-relation Account.loans and Repayment.expenses
- createLoan: accept optional accountId, create 'Lent Money' expense with positive amount, deduct/credit balance, record balance history
- addRepayment: create negative-amount refund expense linked to repaymentId, credit balance, record balance history
- deleteLoan: reverse balance for every linked expense and delete them
- deleteRepayment: find linked refund expense, reverse its balance, then delete
- All mutations wrapped in db.$transaction for atomicity
- UI: account selector in AddLoanDialog, account column + auto-credit notice in LoanList, loan badge + refund badge in ExpenseTable
- Loan-linked expenses are read-only in ExpenseTable (managed via loan)