### PR TITLE
feat(telegram): add account selection for quick expenses

### DIFF
--- a/app/(dashboard)/telegram/page.tsx
+++ b/app/(dashboard)/telegram/page.tsx
@@ -30,8 +30,8 @@ export default async function TelegramPage() {
               Tap an amount button and it&apos;s saved instantly!
             </p>
             <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
-              <li>• Send <code>25</code> → tap ₹25 → instantly saved</li>
-              <li>• Use <code>/quick</code> → tap ₹50 → instantly saved</li>
+              <li>• Send <code>25</code> → pick account → instantly saved</li>
+              <li>• Use <code>/quick</code> → tap ₹50 → pick account → saved</li>
               <li>• No AI, no review, no typing needed</li>
               <li>• Categorised as &quot;General&quot; by default</li>
             </ul>

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -82,6 +82,13 @@ const pendingExpenses = new Map<number, {
  expiresAt: number;
 }>();
 
+// Store pending quick expenses awaiting account selection (in-memory, resets on server restart)
+const pendingQuickExpenses = new Map<number, {
+ userId: string;
+ amount: number;
+ expiresAt: number;
+}>();
+
 // Handle summary command - /summary [today|week|month]
 async function handleSummaryCommand(chatId: number, args: string) {
  const userSettings = await db.userSettings.findFirst({
@@ -197,7 +204,7 @@ async function handleHelpCommand(chatId: number) {
 <i>Tip: You can also send voice messages to add expenses!</i>
 
 <b>Quick Expenses</b>
-• Send just a number (e.g., <code>25</code>) or use <code>/quick</code> — tap an amount and it’s saved instantly!`;
+• Send just a number (e.g., <code>25</code>) or use <code>/quick</code> — tap an amount, then pick an account to save instantly!`;
 
  await sendTelegramMessage(chatId, helpMessage);
 }
@@ -218,12 +225,12 @@ async function handleQuickCommand(chatId: number) {
 
  await sendTelegramMessage(
  chatId,
- "Quick-expense buttons are at the bottom of the chat. Tap any amount to save instantly!",
+ "Quick-expense buttons are at the bottom. Tap an amount, then pick the account to charge.",
  buildQuickReplyKeyboard()
  );
 }
 
-// Handle quick expense - saves immediately without confirmation
+// Handle quick expense - shows account selection inline keyboard
 // Works for both inline button taps (with messageId) and direct text messages (messageId=0)
 async function handleQuickExpenseTap(
  chatId: number,
@@ -240,29 +247,82 @@ async function handleQuickExpenseTap(
  return;
  }
 
- // Find first active account for this user
- const account = await db.account.findFirst({
- where: { userId: userSettings.userId, isActive: true },
- orderBy: { createdAt: "asc" },
+ const accounts = await getAccountsByUserId(userSettings.userId);
+
+ if (accounts.length === 0) {
+ const text = "No accounts found. Please add accounts in Chamber first.";
+ if (messageId > 0) {
+ await editMessageText(chatId, messageId, text);
+ } else {
+ await sendTelegramMessage(chatId, text, buildQuickReplyKeyboard());
+ }
+ if (callbackQueryId) await answerCallbackQuery(callbackQueryId, "No accounts");
+ return;
+ }
+
+ // Store pending quick expense so we can save it after account selection
+ pendingQuickExpenses.set(chatId, {
+ userId: userSettings.userId,
+ amount,
+ expiresAt: Date.now() + 5 * 60 * 1000, // 5 minutes
  });
+
+ const text = `<b>Select account for ₹${amount.toFixed(2)} quick expense:</b>`;
+ const keyboard = buildAccountKeyboard(accounts, "qpay_");
+
+ if (messageId > 0) {
+ await editMessageText(chatId, messageId, text, keyboard);
+ } else {
+ await sendTelegramMessage(chatId, text, keyboard);
+ }
+
+ if (callbackQueryId) {
+ await answerCallbackQuery(callbackQueryId, "Select account");
+ }
+}
+
+// Save a quick expense after the user picks an account
+async function handleQuickAccountSelection(
+ chatId: number,
+ messageId: number,
+ callbackQueryId: string,
+ accountId: string
+) {
+ const pending = pendingQuickExpenses.get(chatId);
+
+ if (!pending || pending.expiresAt <= Date.now()) {
+ pendingQuickExpenses.delete(chatId);
+ await editMessageText(chatId, messageId, "⏰ Expired. Please send the amount again.");
+ await answerCallbackQuery(callbackQueryId, "Expired");
+ return;
+ }
+
+ const account = await db.account.findFirst({
+ where: { id: accountId, userId: pending.userId },
+ });
+
+ if (!account) {
+ await editMessageText(chatId, messageId, "Account not found or access denied. Please try again.");
+ await answerCallbackQuery(callbackQueryId, "Account not found");
+ return;
+ }
 
  try {
  await db.$transaction(async (tx) => {
  await tx.expense.create({
  data: {
- userId: userSettings.userId,
- amount,
+ userId: pending.userId,
+ amount: pending.amount,
  category: QUICK_DEFAULT_CATEGORY,
  description: "Quick expense",
  source: "TELEGRAM",
- accountId: account?.id,
- paymentMethod: account?.name,
+ accountId: account.id,
+ paymentMethod: account.name,
  date: new Date(),
  },
  });
 
- if (account) {
- const adjustment = getTelegramBalanceAdjustment(account.type, amount);
+ const adjustment = getTelegramBalanceAdjustment(account.type, pending.amount);
  const updatedAccount = await tx.account.update({
  where: { id: account.id },
  data: { currentBalance: { increment: adjustment } },
@@ -271,42 +331,26 @@ async function handleQuickExpenseTap(
  data: {
  accountId: account.id,
  balance: updatedAccount.currentBalance,
- note: `Quick expense: ₹${amount}`,
+ note: `Quick expense: ₹${pending.amount}`,
  date: new Date(),
  },
  });
- }
  });
 
- notifyUser(userSettings.userId);
+ notifyUser(pending.userId);
+ checkAndSendSubscriptionAlerts(pending.userId).catch(console.error);
+ pendingQuickExpenses.delete(chatId);
 
- // Check subscription alerts (non-blocking)
- checkAndSendSubscriptionAlerts(userSettings.userId).catch(console.error);
-
- const successText = `<b>Saved!</b> Amount: ₹${amount.toFixed(2)} · ${account?.name || "No account"}`;
-
- if (messageId > 0) {
- // Called from inline button tap - edit the existing message
- await editMessageText(chatId, messageId, successText);
- } else {
- // Called from direct text message - send new message with reply keyboard
- await sendTelegramMessage(chatId, successText, buildQuickReplyKeyboard());
- }
-
- if (callbackQueryId) {
+ await editMessageText(
+ chatId,
+ messageId,
+ `<b>Saved!</b>\n\n₹${pending.amount.toFixed(2)} · ${account.name}`
+ );
  await answerCallbackQuery(callbackQueryId, "Saved!");
- }
  } catch (error) {
  console.error("Quick expense save error:", error);
- const errText = "Failed to save expense. Please try again.";
- if (messageId > 0) {
- await editMessageText(chatId, messageId, errText);
- } else {
- await sendTelegramMessage(chatId, errText);
- }
- if (callbackQueryId) {
+ await editMessageText(chatId, messageId, "Failed to save expense. Please try again.");
  await answerCallbackQuery(callbackQueryId, "Failed");
- }
  }
 }
 
@@ -416,18 +460,21 @@ function buildQuickReplyKeyboard(): object {
 }
 
 // Build inline keyboard from user's accounts (uses accountId in callback_data)
-function buildAccountKeyboard(accounts: { id: string; name: string; type: string }[]) {
+function buildAccountKeyboard(
+ accounts: { id: string; name: string; type: string }[],
+ callbackPrefix: string = "pay_"
+) {
  const rows: { text: string; callback_data: string }[][] = [];
  for (let i = 0; i < accounts.length; i += 2) {
  const row: { text: string; callback_data: string }[] = [];
  row.push({
  text: `${ACCOUNT_TYPE_ICONS[accounts[i].type] || "\u{1F4B0}"} ${accounts[i].name}`,
- callback_data: `pay_${accounts[i].id}`,
+ callback_data: `${callbackPrefix}${accounts[i].id}`,
  });
  if (i + 1 < accounts.length) {
  row.push({
  text: `${ACCOUNT_TYPE_ICONS[accounts[i + 1].type] || "\u{1F4B0}"} ${accounts[i + 1].name}`,
- callback_data: `pay_${accounts[i + 1].id}`,
+ callback_data: `${callbackPrefix}${accounts[i + 1].id}`,
  });
  }
  rows.push(row);
@@ -605,7 +652,7 @@ async function handleStartCommand(chatId: number, code: string) {
 
  await sendTelegramMessage(
  chatId,
- "<b>Account linked successfully!</b>\n\nQuick-expense buttons are now at the bottom. Tap any amount to save instantly!\n\nYou can also type expenses like:\n• <code>Lunch 450</code>\n• <code>Uber 250</code>\n• Or send a receipt photo",
+ "<b>Account linked successfully!</b>\n\nQuick-expense buttons are now at the bottom. Tap an amount, then pick the account to charge.\n\nYou can also type expenses like:\n• <code>Lunch 450</code>\n• <code>Uber 250</code>\n• Or send a receipt photo",
  buildQuickReplyKeyboard()
  );
 }
@@ -737,7 +784,7 @@ async function handlePhotoMessage(chatId: number, photo: TelegramMessage["photo"
  console.log("Caption has expense info, using free text model:", caption);
  aiResult = await parseExpenseWithAI(`User sent a payment screenshot with this caption: "${caption}"`, userSettings.currency || "INR");
  } else {
- // Send image directly to GPT-4.1 Nano vision — no OCR needed
+ // Send image directly to GPT-4.1 Nano vision - no OCR needed
  console.log("Sending image to Vision AI (GPT-4.1 Nano)...");
  aiResult = await parseReceiptWithVision(imageBase64, "image/jpeg", caption, userSettings.currency || "INR");
  }
@@ -800,7 +847,7 @@ async function handlePhotoMessage(chatId: number, photo: TelegramMessage["photo"
  await sendTelegramMessage(chatId, confirmMsg, keyboard);
 }
 
-// Handle PDF document messages — now also supports image files
+// Handle PDF document messages - now also supports image files
 async function handleDocumentMessage(chatId: number, document: TelegramMessage["document"], caption?: string) {
  // Find user by chat ID
  const userSettings = await db.userSettings.findFirst({
@@ -958,7 +1005,7 @@ export async function POST(request: NextRequest) {
  const data = callbackQuery.data;
 
  if (chatId && messageId) {
- // Handle quick expense tap - save instantly without confirmation
+ // Handle quick expense tap - show account selection
  if (data?.startsWith("quick_")) {
  const amountStr = data.replace("quick_", "");
  if (amountStr === "cancel") {
@@ -970,6 +1017,9 @@ export async function POST(request: NextRequest) {
  await handleQuickExpenseTap(chatId, messageId, callbackQuery.id, amount);
  }
  }
+ } else if (data?.startsWith("qpay_")) {
+ const accountId = data.replace("qpay_", "");
+ await handleQuickAccountSelection(chatId, messageId, callbackQuery.id, accountId);
  } else if (data?.startsWith("pay_")) {
  const accountId = data.replace("pay_", "");
  const pending = pendingExpenses.get(chatId);
@@ -1039,6 +1089,7 @@ export async function POST(request: NextRequest) {
  }
  } else if (data === "confirm_no") {
  pendingExpenses.delete(chatId);
+ pendingQuickExpenses.delete(chatId);
  await editMessageText(chatId, messageId, " Cancelled. Send another expense or receipt.");
  await answerCallbackQuery(callbackQuery.id, "Cancelled");
  }
@@ -1094,7 +1145,7 @@ export async function POST(request: NextRequest) {
  where: { telegramChatId: chatId.toString() },
  });
  if (userSettings) {
- // Save directly without any confirmation
+ // Show account selection for the quick amount
  await handleQuickExpenseTap(chatId, 0, "", quickAmount);
  return NextResponse.json({ ok: true });
  }

--- a/tests/unit/api/telegram/webhook.test.ts
+++ b/tests/unit/api/telegram/webhook.test.ts
@@ -689,7 +689,7 @@ describe("Telegram Webhook", () => {
 
             expect(sendMessageCall).toBeDefined();
             const body = JSON.parse(String(sendMessageCall?.[1]?.body));
-            expect(body.text).toContain("buttons are at the bottom");
+            expect(body.text).toContain("bottom");
             expect(body.reply_markup).toBeDefined();
             expect(body.reply_markup.keyboard).toBeDefined();
             // Should have amount buttons in the reply keyboard
@@ -697,25 +697,17 @@ describe("Telegram Webhook", () => {
             expect(allButtons.length).toBeGreaterThanOrEqual(5);
         });
 
-        it("should instantly save expense when quick-amount button is tapped", async () => {
+        it("should show account selection when quick-amount inline button is tapped", async () => {
+            const { getAccountsByUserId } = await import("@/lib/actions/accounts");
+            vi.mocked(getAccountsByUserId).mockResolvedValue([
+                { id: "acc-1", name: "Cash Wallet", type: "WALLET" },
+                { id: "acc-2", name: "HDFC Bank", type: "BANK" },
+            ]);
+
             mockDb.userSettings.findFirst.mockResolvedValue({
                 userId: "test-user-id",
                 currency: "INR",
                 telegramChatId: "123456",
-            });
-
-            mockDb.account.findFirst.mockResolvedValue({
-                id: "acc-1",
-                name: "Cash Wallet",
-                type: "WALLET",
-                currentBalance: 5000,
-            });
-
-            mockDb.account.update.mockResolvedValue({
-                id: "acc-1",
-                name: "Cash Wallet",
-                type: "WALLET",
-                currentBalance: 4975,
             });
 
             const { POST } = await import("@/app/api/telegram/webhook/route");
@@ -741,33 +733,26 @@ describe("Telegram Webhook", () => {
 
             await POST(request);
 
-            // Should create expense with amount 25 and default category
-            expect(mockDb.expense.create).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    data: expect.objectContaining({
-                        amount: 25,
-                        category: "General",
-                        userId: "test-user-id",
-                    }),
-                })
-            );
+            // Should NOT create expense yet (account not selected)
+            expect(mockDb.expense.create).not.toHaveBeenCalled();
 
-            // Should update account balance
-            expect(mockDb.account.update).toHaveBeenCalled();
-            expect(mockDb.balanceHistory.create).toHaveBeenCalled();
-
-            // Should edit the message to show success
+            // Should edit the message to show account selection
             const fetchCalls = vi.mocked(fetch).mock.calls;
             const editCall = fetchCalls.find((call) =>
                 String(call[0]).includes("/editMessageText")
             );
             expect(editCall).toBeDefined();
             const body = JSON.parse(String(editCall?.[1]?.body));
-            expect(body.text).toContain("Saved!");
-            expect(body.text).toContain("₹25.00");
+            expect(body.text).toContain("Select account for ₹25.00");
+            expect(body.reply_markup.inline_keyboard).toBeDefined();
         });
 
-        it("should detect quick expense from a bare number message", async () => {
+        it("should save expense after account is selected via qpay callback", async () => {
+            const { getAccountsByUserId } = await import("@/lib/actions/accounts");
+            vi.mocked(getAccountsByUserId).mockResolvedValue([
+                { id: "acc-1", name: "Cash Wallet", type: "WALLET" },
+            ]);
+
             mockDb.userSettings.findFirst.mockResolvedValue({
                 userId: "test-user-id",
                 currency: "INR",
@@ -786,6 +771,93 @@ describe("Telegram Webhook", () => {
                 name: "Cash Wallet",
                 type: "WALLET",
                 currentBalance: 4975,
+            });
+
+            const { POST } = await import("@/app/api/telegram/webhook/route");
+
+            // Step 1: tap quick amount to set pending quick expense
+            const step1 = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 124,
+                    callback_query: {
+                        id: "cq-1",
+                        from: { id: 123456 },
+                        message: {
+                            chat: { id: 123456 },
+                            message_id: 100,
+                        },
+                        data: "quick_25",
+                    },
+                }),
+            });
+            await POST(step1);
+
+            // Step 2: select account via qpay callback
+            const step2 = new Request("http://localhost/api/telegram/webhook", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-telegram-bot-api-secret-token": "test-webhook-secret",
+                },
+                body: JSON.stringify({
+                    update_id: 125,
+                    callback_query: {
+                        id: "cq-2",
+                        from: { id: 123456 },
+                        message: {
+                            chat: { id: 123456 },
+                            message_id: 100,
+                        },
+                        data: "qpay_acc-1",
+                    },
+                }),
+            });
+            await POST(step2);
+
+            // Should create expense with amount 25 and default category
+            expect(mockDb.expense.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        amount: 25,
+                        category: "General",
+                        userId: "test-user-id",
+                        accountId: "acc-1",
+                        paymentMethod: "Cash Wallet",
+                    }),
+                })
+            );
+
+            // Should update account balance
+            expect(mockDb.account.update).toHaveBeenCalled();
+            expect(mockDb.balanceHistory.create).toHaveBeenCalled();
+
+            // Should edit the message to show success
+            const fetchCalls = vi.mocked(fetch).mock.calls;
+            const editCalls = fetchCalls.filter((call) =>
+                String(call[0]).includes("/editMessageText")
+            );
+            expect(editCalls.length).toBeGreaterThanOrEqual(2);
+            const lastEditBody = JSON.parse(String(editCalls[editCalls.length - 1]?.[1]?.body));
+            expect(lastEditBody.text).toContain("Saved!");
+            expect(lastEditBody.text).toContain("₹25.00");
+            expect(lastEditBody.text).toContain("Cash Wallet");
+        });
+
+        it("should show account selection for a bare number message", async () => {
+            const { getAccountsByUserId } = await import("@/lib/actions/accounts");
+            vi.mocked(getAccountsByUserId).mockResolvedValue([
+                { id: "acc-1", name: "Cash Wallet", type: "WALLET" },
+            ]);
+
+            mockDb.userSettings.findFirst.mockResolvedValue({
+                userId: "test-user-id",
+                currency: "INR",
+                telegramChatId: "123456",
             });
 
             const { POST } = await import("@/app/api/telegram/webhook/route");
@@ -809,26 +881,18 @@ describe("Telegram Webhook", () => {
 
             await POST(request);
 
-            // Should save directly (not show inline buttons)
-            expect(mockDb.expense.create).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    data: expect.objectContaining({
-                        amount: 25,
-                        category: "General",
-                        userId: "test-user-id",
-                    }),
-                })
-            );
+            // Should NOT create expense yet (account not selected)
+            expect(mockDb.expense.create).not.toHaveBeenCalled();
 
-            // Should send success message with reply keyboard
+            // Should send account selection message
             const fetchCalls = vi.mocked(fetch).mock.calls;
             const sendMessageCall = fetchCalls.find((call) =>
                 String(call[0]).includes("/sendMessage")
             );
             expect(sendMessageCall).toBeDefined();
             const body = JSON.parse(String(sendMessageCall?.[1]?.body));
-            expect(body.text).toContain("Saved!");
-            expect(body.text).toContain("₹25");
+            expect(body.text).toContain("Select account for ₹25.00");
+            expect(body.reply_markup.inline_keyboard).toBeDefined();
         });
 
         it("should not trigger quick expense for amounts over 200", async () => {


### PR DESCRIPTION
Quick expense flow (reply keyboard amounts or bare number messages) now shows an inline keyboard with the user's accounts instead of auto-saving to the first account.

- Added pendingQuickExpenses map for 2-step quick expense flow
- handleQuickExpenseTap now prompts account selection via qpay_ callbacks
- Added handleQuickAccountSelection to save after user picks an account
- buildAccountKeyboard accepts a callbackPrefix for reuse
- Updated help text and dashboard guide to reflect new flow
- Updated tests for the 2-step quick expense flow