### PR TITLE
fix: make CRON_SECRET mandatory in cron endpoint

### DIFF
--- a/app/api/cron/subscription-alerts/route.ts
+++ b/app/api/cron/subscription-alerts/route.ts
@@ -32,10 +32,14 @@ async function sendTelegramMessage(chatId: string, text: string) {
 
 export async function GET(request: NextRequest) {
  // Verify cron secret to prevent unauthorized access
- const authHeader = request.headers.get("authorization");
  const cronSecret = process.env.CRON_SECRET;
+ if (!cronSecret) {
+ console.error("CRON_SECRET not configured — cron endpoint disabled");
+ return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
+ }
 
- if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+ const authHeader = request.headers.get("authorization");
+ if (authHeader !== `Bearer ${cronSecret}`) {
  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
  }
 


### PR DESCRIPTION
Closes #38

## What

The cron endpoint at `/api/cron/subscription-alerts` only checked `CRON_SECRET` if the env var was set. If unset (misconfiguration), auth was skipped entirely — anyone could trigger it.

## Fix

- Require `CRON_SECRET` to be set, return 500 + log if missing
- Auth check is now unconditional

## Verification
- ✅ `pnpm lint` — 0 errors
- ✅ `pnpm test:run` — 93/93 pass